### PR TITLE
'Positional arg after keyword arg' error for star arguments 

### DIFF
--- a/src/main/kotlin/com/jetbrains/snakecharm/lang/validation/SmkSyntaxErrorAnnotator.kt
+++ b/src/main/kotlin/com/jetbrains/snakecharm/lang/validation/SmkSyntaxErrorAnnotator.kt
@@ -1,6 +1,7 @@
 package com.jetbrains.snakecharm.lang.validation
 
 import com.jetbrains.python.psi.PyKeywordArgument
+import com.jetbrains.python.psi.PyStarArgument
 import com.jetbrains.snakecharm.SnakemakeBundle
 import com.jetbrains.snakecharm.inspections.quickfix.IntroduceKeywordArgument
 import com.jetbrains.snakecharm.lang.SnakemakeLanguageDialect
@@ -32,7 +33,7 @@ object SmkSyntaxErrorAnnotator : SmkAnnotator() {
                     }
                     encounteredKeywordArgument = true
                 }
-                else -> if (encounteredKeywordArgument) {
+                !is PyStarArgument -> if (encounteredKeywordArgument) {
                     holder.createErrorAnnotation(
                             arg,
                             SnakemakeBundle.message("ANN.positional.argument.after.keyword.argument")

--- a/src/test/resources/com/jetbrains/snakecharm/cucumber/actions/annotator_and_inspection_quick_fixes.feature
+++ b/src/test/resources/com/jetbrains/snakecharm/cucumber/actions/annotator_and_inspection_quick_fixes.feature
@@ -210,3 +210,22 @@ Feature: Inspection quick fixes
       | rule_like  |
       | rule       |
       | checkpoint |
+
+  Scenario Outline: no error highlighting for star arguments
+    Given a snakemake project
+    Given I open a file "foo.smk" with text
+    """
+    def dictfunc():
+        return {'foo': 'nowildcards.txt'}
+
+    <rule_like> NAME:
+        output:
+              a = "file.out", **dictfunct()
+        shell: "echo hhh > {output.foo} | echo uuu > {output.a}"
+    """
+    Then I expect no inspection error
+    When I check highlighting errors
+    Examples:
+      | rule_like  |
+      | rule       |
+      | checkpoint |

--- a/src/test/resources/com/jetbrains/snakecharm/cucumber/highlighting/smk_syntax_error_annotator.feature
+++ b/src/test/resources/com/jetbrains/snakecharm/cucumber/highlighting/smk_syntax_error_annotator.feature
@@ -63,6 +63,26 @@ Feature: Annotate syntax errors
       | checkpoint |
 
 
+  Scenario Outline: no error highlighting for star arguments
+    Given a snakemake project
+    Given I open a file "foo.smk" with text
+    """
+    def dictfunc():
+        return {'foo': 'nowildcards.txt'}
+
+    <rule_like> NAME:
+        output:
+              a = "file.out", **dictfunct()
+        shell: "echo hhh > {output.foo} | echo uuu > {output.a}"
+    """
+    Then I expect no inspection error
+    When I check highlighting errors
+    Examples:
+      | rule_like  |
+      | rule       |
+      | checkpoint |
+
+
 
 
 


### PR DESCRIPTION
False position arg after keyword arg inspection warning  https://github.com/JetBrains-Research/snakecharm/issues/210

There was a syntax error annotator bug where `positional argument after keyword argument` error would be displayed for unpacked dictionaries or lists, and if you tried to invoke `IntroduceKeywordArgument` quick fix on it, there would be an exception. Star arguments in general shouldn't be highlighted in this case. See `CompatibilityVisitor` class, `highlightIncorrectArguments()` method.