### PR TITLE
#260 Error for using reference expression without defining args, when it is necessary

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -12,6 +12,7 @@ Features:
 - Inspection: Comma in the end of section arg list isn't needed (see #255)
 - Inspection: Warn user if rule from 'rulesorder' isn't available in current or included files (see #254)
 - Inspection: Warn about string arguments split on several lines (see #259)
+- Inspection: Error with using reference expression without defining wildcard (see #260)
 
 Fixed:
 - Completion does not suggest top-level keywords in comments (see #178)

--- a/src/main/kotlin/com/jetbrains/snakecharm/inspections/SmkWildcardNotDefinedInExpressionInspection.kt
+++ b/src/main/kotlin/com/jetbrains/snakecharm/inspections/SmkWildcardNotDefinedInExpressionInspection.kt
@@ -1,0 +1,98 @@
+package com.jetbrains.snakecharm.inspections
+
+import com.intellij.codeInspection.LocalInspectionToolSession
+import com.intellij.codeInspection.ProblemsHolder
+import com.intellij.openapi.util.Ref
+import com.intellij.psi.util.PsiTreeUtil
+import com.intellij.psi.util.elementType
+import com.jetbrains.python.psi.PyReferenceExpression
+import com.jetbrains.python.psi.impl.PyCallExpressionImpl
+import com.jetbrains.snakecharm.SnakemakeBundle
+import com.jetbrains.snakecharm.codeInsight.SnakemakeAPI.SMK_FUN_EXPAND
+import com.jetbrains.snakecharm.codeInsight.SnakemakeAPI.SMK_VARS_RULES
+import com.jetbrains.snakecharm.inspections.smksl.SmkWildcardNotDefinedInspection
+import com.jetbrains.snakecharm.lang.psi.SmkRuleOrCheckpoint
+import com.jetbrains.snakecharm.lang.psi.SmkRuleOrCheckpointArgsSection
+import com.jetbrains.snakecharm.lang.psi.SmkWildcardsCollector
+import com.jetbrains.snakecharm.lang.psi.elementTypes.SmkElementTypes.SMK_PY_REFERENCE_EXPRESSION
+
+class SmkWildcardNotDefinedInExpressionInspection : SnakemakeInspection() {
+
+    override fun buildVisitor(
+            holder: ProblemsHolder,
+            isOnTheFly: Boolean,
+            session: LocalInspectionToolSession
+    ) = object : SnakemakeInspectionVisitor(holder, session) {
+
+
+        override fun visitPyReferenceExpression(node: PyReferenceExpression?) {
+
+            if (node?.text != SMK_VARS_RULES) {
+                return
+            }
+
+            val callExpression = PsiTreeUtil.getParentOfType(node, PyCallExpressionImpl::class.java)
+
+            if (callExpression?.firstChild?.text == SMK_FUN_EXPAND) {
+                return
+            }
+
+            var lastReference = node
+
+            while (lastReference?.parent.elementType == SMK_PY_REFERENCE_EXPRESSION) {
+                lastReference = lastReference?.parent as PyReferenceExpression?
+            }
+
+            val reference = lastReference?.reference?.resolve()
+
+            var collector = SmkWildcardsCollector(
+                    visitDefiningSections = false,
+                    visitExpandingSections = true
+            )
+
+            reference?.accept(collector)
+
+            val necessaryWildcards = collector.getWildcardsNames()
+
+            val ruleOrCheckpoint = PsiTreeUtil.getParentOfType(node, SmkRuleOrCheckpoint::class.java) ?: return
+
+            val wildcardsByRule = session.putUserDataIfAbsent(SmkWildcardNotDefinedInspection.KEY, hashMapOf())
+
+            if (ruleOrCheckpoint !in wildcardsByRule) {
+                val wildcardsDefiningSectionsAvailable = ruleOrCheckpoint.getSections()
+                        .asSequence()
+                        .filterIsInstance(SmkRuleOrCheckpointArgsSection::class.java)
+                        .filter { it.isWildcardsDefiningSection() }.firstOrNull() != null
+
+                val wildcards = when {
+                    // if no suitable sections let's think that no wildcards
+                    !wildcardsDefiningSectionsAvailable -> emptyList()
+                    else -> {
+                        // Cannot do via types, we'd like to have wildcards only from
+                        // defining sections and ensure that defining sections could be parsed
+                        collector = SmkWildcardsCollector(
+                                visitDefiningSections = true,
+                                visitExpandingSections = false
+                        )
+
+                        ruleOrCheckpoint.accept(collector)
+                        collector.getWildcardsNames()
+                    }
+                }
+                wildcardsByRule[ruleOrCheckpoint] =  Ref.create(wildcards)
+            }
+            val availableWildcards = wildcardsByRule.getValue(ruleOrCheckpoint).get()
+
+            necessaryWildcards?.forEach { wildcard ->
+                if (wildcard !in availableWildcards){
+                    if (lastReference != null) {
+                        registerProblem(
+                                lastReference.lastChild,
+                                SnakemakeBundle.message("INSP.NAME.wildcard.not.defined.in.expression", wildcard)
+                        )
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -416,6 +416,17 @@
             implementationClass="com.jetbrains.snakecharm.inspections.SmkRedundantCommaInspection"
     />
 
+    <localInspection
+            language="Snakemake" shortName="SmkWildcardNotDefinedInExpressionInspection"
+            enabledByDefault="true"
+            level="ERROR"
+            suppressId="SmkWildcardNotDefinedInExpression"
+            bundle="SnakemakeBundle"
+            groupKey="INSP.GROUP.snakemake"
+            key="INSP.NAME.wildcard.not.defined.in.expression.title"
+            implementationClass="com.jetbrains.snakecharm.inspections.SmkWildcardNotDefinedInExpressionInspection"
+    />
+
     <findUsagesHandlerFactory
             implementation="com.jetbrains.snakecharm.codeInsight.refactoring.SmkFindUsagesHandlerFactory"
             id="Python" order="last, before default"

--- a/src/main/resources/SnakemakeBundle.properties
+++ b/src/main/resources/SnakemakeBundle.properties
@@ -103,6 +103,10 @@ INSP.NAME.wildcards.confusing.name.with.dot.message=Confusing wildcard name: ''{
 INSP.NAME.redundant.comma.title=Comma is unnecessary
 INSP.NAME.redundant.comma.fix.message=Remove redundant comma
 
+# SmkWildcardNotDefinedInExpressionInspection
+INSP.NAME.wildcard.not.defined.in.expression.title=Undefined wildcard usage.
+INSP.NAME.wildcard.not.defined.in.expression=Wildcard ''{0}'' isn''t properly defined.
+
 # SmkPyUnboundLocalVariableInspection
 INSP.NAME.unbound=Unbound local variable
 

--- a/src/main/resources/inspectionDescriptions/SmkWildcardNotDefinedInExpressionInspection.html
+++ b/src/main/resources/inspectionDescriptions/SmkWildcardNotDefinedInExpressionInspection.html
@@ -1,0 +1,5 @@
+<html>
+<body>
+Fetch correct wildcards if arg value in rule is link to other section or section arg
+</body>
+</html>

--- a/src/test/resources/features/highlighting/inspections/wildcard_not_defined_in_expression_inspection.feature
+++ b/src/test/resources/features/highlighting/inspections/wildcard_not_defined_in_expression_inspection.feature
@@ -1,0 +1,68 @@
+Feature: Inspection for defining wildcard in expression
+
+  Scenario Outline: Defining incorrect wildcard in expression
+    Given a snakemake project
+    Given I open a file "foo.smk" with text
+    """
+    rule foo1:
+        output:
+            out1 = "/path/{sample}_{genome}.1",
+            out2 = "/path/{sample}_{genome}.2"
+
+    rule foo2:
+        output:
+            "/path/{sample}.txt"
+
+    rule foo3:
+        output:  "/path/{genome}.txt",
+
+    <rule_like> NAME:
+        output: "{sample}.txt"
+        <section>: <expression_first_part><expression_second_part>
+    """
+    And SmkWildcardNotDefinedInExpressionInspection inspection is enabled
+    Then I expect inspection error on <<expression_second_part>> in <<section>: <expression_first_part><expression_second_part>> with message
+    """
+    Wildcard 'genome' isn't properly defined.
+    """
+    When I check highlighting errors
+    Examples:
+      | rule_like   | section    | expression_first_part  | expression_second_part |
+      | rule        | input      | rules.foo1.output.     | out1                   |
+      | rule        | input      | rules.foo3.            | output                 |
+      | rule        | params     | rules.foo1.output.     | out1                   |
+      | rule        | params     | rules.foo3.            | output                 |
+      | checkpoint  | input      | rules.foo1.output.     | out1                   |
+      | checkpoint  | input      | rules.foo3.            | output                 |
+      | checkpoint  | params     | rules.foo1.output.     | out1                   |
+      | checkpoint  | params     | rules.foo3.            | output                 |
+
+  Scenario Outline: Defining correct wildcard in expression
+    Given a snakemake project
+    Given I open a file "foo.smk" with text
+    """
+    rule foo1:
+        output:
+            out1 = "/path/{sample}_{genome}.1",
+            out2 = "/path/{sample}_{genome}.2"
+
+    rule foo2:
+        output:
+            "/path/{sample}.txt"
+
+    rule foo3:
+        output:  "/path/{genome}.txt",
+
+    <rule_like> NAME:
+        output: "{sample}.txt"
+        <section>: <expression_first_part>
+    """
+    And SmkWildcardNotDefinedInExpressionInspection inspection is enabled
+    Then I expect no inspection errors
+    When I check highlighting errors
+    Examples:
+      | rule_like   | section    | expression_first_part          |
+      | rule        | input      | rules.foo2.output              |
+      | rule        | input      | expand(rules.foo1.output.out2) |
+      | checkpoint  | input      | rules.foo2.output              |
+      | checkpoint  | input      | expand(rules.foo1.output.out2) |


### PR DESCRIPTION
Error for using reference expression without defining args, when it is necessary.

Fixes: #260