### PR TITLE
Features/#362 handover support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Released on ...
 - TODO  (see [#NNN](https://github.com/JetBrains-Research/snakecharm/issues/NNN)) 
 
 ### Fixed
+- Support for 'handover' section (see [#362](https://github.com/JetBrains-Research/snakecharm/issues/362))
 - TODO  (see [#NNN](https://github.com/JetBrains-Research/snakecharm/issues/NNN))
 
 ## [2021.2.424]

--- a/src/main/kotlin/com/jetbrains/snakecharm/codeInsight/SnakemakeAPI.kt
+++ b/src/main/kotlin/com/jetbrains/snakecharm/codeInsight/SnakemakeAPI.kt
@@ -8,6 +8,7 @@ import com.jetbrains.snakecharm.lang.SnakemakeNames.SECTION_CONTAINER
 import com.jetbrains.snakecharm.lang.SnakemakeNames.SECTION_CWL
 import com.jetbrains.snakecharm.lang.SnakemakeNames.SECTION_ENVMODULES
 import com.jetbrains.snakecharm.lang.SnakemakeNames.SECTION_GROUP
+import com.jetbrains.snakecharm.lang.SnakemakeNames.SECTION_HANDOVER
 import com.jetbrains.snakecharm.lang.SnakemakeNames.SECTION_INPUT
 import com.jetbrains.snakecharm.lang.SnakemakeNames.SECTION_LOG
 import com.jetbrains.snakecharm.lang.SnakemakeNames.SECTION_MESSAGE
@@ -85,7 +86,8 @@ object SnakemakeAPI {
             SECTION_CWL, SECTION_BENCHMARK, SECTION_VERSION,
             SECTION_MESSAGE, SECTION_THREADS, SECTION_SINGULARITY,
             SECTION_PRIORITY, SECTION_CONDA, SECTION_GROUP,
-            SECTION_SHADOW, SECTION_CACHE, SECTION_NOTEBOOK, SECTION_CONTAINER
+            SECTION_SHADOW, SECTION_CACHE, SECTION_NOTEBOOK, SECTION_CONTAINER,
+            SECTION_HANDOVER
     )
 
     /**
@@ -100,7 +102,8 @@ object SnakemakeAPI {
             SECTION_CACHE,
             SECTION_CONTAINER,
             SECTION_ENVMODULES,
-            SECTION_NAME
+            SECTION_NAME,
+            SECTION_HANDOVER
     )
     val RULE_OR_CHECKPOINT_SECTION_KEYWORDS = (RULE_OR_CHECKPOINT_ARGS_SECTION_KEYWORDS + setOf(SnakemakeNames.SECTION_RUN))
 
@@ -152,7 +155,8 @@ object SnakemakeAPI {
             SECTION_WRAPPER,
             SECTION_VERSION, SECTION_THREADS,
             SECTION_PRIORITY, SECTION_SINGULARITY, SECTION_CACHE,
-            SECTION_CONTAINER, SECTION_NOTEBOOK, SECTION_ENVMODULES
+            SECTION_CONTAINER, SECTION_NOTEBOOK, SECTION_ENVMODULES,
+            SECTION_HANDOVER
     )
 
     /**
@@ -210,7 +214,8 @@ object SnakemakeAPI {
     val SECTIONS_WHERE_KEYWORD_ARGS_PROHIBITED = setOf(
             SECTION_BENCHMARK, SECTION_VERSION, SECTION_MESSAGE, SECTION_SHELL, SECTION_THREADS, SECTION_SINGULARITY,
             SECTION_PRIORITY, SECTION_GROUP, SECTION_SHADOW, SECTION_CONDA, SECTION_SCRIPT, SECTION_WRAPPER,
-            SECTION_CWL, SECTION_NOTEBOOK, SECTION_CACHE, SECTION_CONTAINER, SECTION_ENVMODULES, SECTION_NAME
+            SECTION_CWL, SECTION_NOTEBOOK, SECTION_CACHE, SECTION_CONTAINER, SECTION_ENVMODULES, SECTION_NAME,
+            SECTION_HANDOVER
     )
 
     val IO_FLAG_2_SUPPORTED_SECTION: HashMap<String, List<String>> = hashMapOf(

--- a/src/main/kotlin/com/jetbrains/snakecharm/lang/SnakemakeNames.kt
+++ b/src/main/kotlin/com/jetbrains/snakecharm/lang/SnakemakeNames.kt
@@ -56,6 +56,7 @@ object SnakemakeNames {
     const val SECTION_NOTEBOOK = "notebook"
     const val SECTION_ENVMODULES = "envmodules" // >= 5.9
     const val SECTION_NAME = "name" // >= 5.31
+    const val SECTION_HANDOVER = "handover" // >= 6.2
 
     const val RUN_SECTION_VARIABLE_RULE = "rule"
     const val RUN_SECTION_VARIABLE_JOBID = "jobid"

--- a/src/test/resources/features/completion/after_rule_or_checkpoint_name_completion.feature
+++ b/src/test/resources/features/completion/after_rule_or_checkpoint_name_completion.feature
@@ -58,6 +58,7 @@ Feature: Completion after rule/checkpoint name e.g. rules.NAME.input
       | run         |
       | script      |
       | name        |
+      | handover    |
     Examples:
       | rule_like  | injection_left | injection_right |
       | rule       |                |                 |
@@ -122,6 +123,7 @@ Feature: Completion after rule/checkpoint name e.g. rules.NAME.input
       | run                  |
       | script               |
       | name                 |
+      | handover             |
     Examples:
       | rule_like  |
       | rule       |

--- a/src/test/resources/features/completion/keywords_completion.feature
+++ b/src/test/resources/features/completion/keywords_completion.feature
@@ -215,8 +215,8 @@ Feature: Completion for snakemake keyword-like things
       | checkpoint | lo   | log        |
       | rule       | be   | benchmark  |
       | checkpoint | be   | benchmark  |
-      | rule       | ve   | version    |
-      | checkpoint | ve   | version    |
+      | rule       | vers | version    |
+      | checkpoint | vers | version    |
       | rule       | cac  | cache      |
       | checkpoint | cac  | cache      |
       | rule       | mes  | message    |
@@ -237,6 +237,8 @@ Feature: Completion for snakemake keyword-like things
       | checkpoint | wr   | wrapper    |
       | rule       | na   | name       |
       | checkpoint | na   | name       |
+      | rule       | han  | handover   |
+      | checkpoint | han  | handover   |
 
   Scenario Outline: Complete at rule/checkpoint level
     Given a snakemake project

--- a/src/test/resources/features/completion/smkl_in_section_completion.feature
+++ b/src/test/resources/features/completion/smkl_in_section_completion.feature
@@ -74,6 +74,7 @@ Feature: Completion for sections/variables in SmkSL injections
          priority: 1
          name: "new_rule_name"
          script: ""
+         handover: True
          shell: "{}"
          run: shell("{}")
     """
@@ -96,6 +97,7 @@ Feature: Completion for sections/variables in SmkSL injections
       | script               |
       | cache                |
       | name                 |
+      | handover             |
     Examples:
       | rule_like  | signature     |
       | rule       | shell: "{     |

--- a/src/test/resources/features/highlighting/inspections/multiple_args_inspection.feature
+++ b/src/test/resources/features/highlighting/inspections/multiple_args_inspection.feature
@@ -57,3 +57,4 @@ Feature: Inspection for multiple arguments in various sections
       | shadow      |
       | notebook    |
       | container   |
+      | handover    |

--- a/src/test/resources/features/highlighting/inspections/unexpected_keyword_args_inspection.feature
+++ b/src/test/resources/features/highlighting/inspections/unexpected_keyword_args_inspection.feature
@@ -44,6 +44,7 @@ Feature: Inspection for unexpected keyword arguments in section
       | rule       | singularity |
       | rule       | threads     |
       | rule       | name        |
+      | rule       | handover    |
       | checkpoint | message     |
       | checkpoint | notebook    |
       | checkpoint | priority    |
@@ -52,6 +53,7 @@ Feature: Inspection for unexpected keyword arguments in section
       | checkpoint | shell       |
       | checkpoint | version     |
       | checkpoint | wrapper     |
+      | checkpoint | handover    |
 
   Scenario Outline: No warn on expected keyword arguments in rule\checkpoint
     Given a snakemake project

--- a/src/test/resources/features/highlighting/smk_syntax_annotator.feature
+++ b/src/test/resources/features/highlighting/smk_syntax_annotator.feature
@@ -96,6 +96,7 @@ Feature: Annotate additional syntax
       | rule       | run                  | ""         | PY.PREDEFINED_DEFINITION |
       | rule       | wrapper              | ""         | PY.DECORATOR             |
       | rule       | name                 | ""         | PY.DECORATOR             |
+      | rule       | handover             | ""         | PY.DECORATOR             |
       | checkpoint | output               | "file.txt" | PY.DECORATOR             |
       | checkpoint | run                  | ""         | PY.PREDEFINED_DEFINITION |
 

--- a/src/test/resources/features/resolve/after_rule_or_checkpoint_name_resolve.feature
+++ b/src/test/resources/features/resolve/after_rule_or_checkpoint_name_resolve.feature
@@ -160,6 +160,7 @@ Feature: Resolve for section after rule/checkpoint name e.g. rules.NAME.input
          script: ""
          shell: ""
          cache: True
+         handover: True
          run:
 
      rule ANOTHER_NAME:
@@ -181,6 +182,7 @@ Feature: Resolve for section after rule/checkpoint name e.g. rules.NAME.input
       | script      |
       | cache       |
       | name        |
+      | handover    |
 
   Scenario Outline: Resolve for available sections
     Given a snakemake project

--- a/src/test/resources/features/resolve/rules_and_checkpoints_sections_names_resolve.feature
+++ b/src/test/resources/features/resolve/rules_and_checkpoints_sections_names_resolve.feature
@@ -55,16 +55,18 @@ Feature: Resolve for section names in rules and checkpoints
       | <section> | <file> | <times> | <class> |
 
     Examples:
-      | rule_like  | text          | section   | file    | times | class                              |
-      | rule       | output: ""    | output    | foo.smk | 1     | SmkRuleOrCheckpointArgsSectionImpl |
-      | rule       | input: ""     | input     | foo.smk | 1     | SmkRuleOrCheckpointArgsSectionImpl |
-      | rule       | params: ""    | params    | foo.smk | 1     | SmkRuleOrCheckpointArgsSectionImpl |
-      | rule       | log: ""       | log       | foo.smk | 1     | SmkRuleOrCheckpointArgsSectionImpl |
-      | rule       | resources: "" | resources | foo.smk | 1     | SmkRuleOrCheckpointArgsSectionImpl |
-      | rule       | version: ""   | version   | foo.smk | 1     | SmkRuleOrCheckpointArgsSectionImpl |
-      | rule       | threads: 1    | threads   | foo.smk | 1     | SmkRuleOrCheckpointArgsSectionImpl |
-      | checkpoint | output: ""    | output    | foo.smk | 1     | SmkRuleOrCheckpointArgsSectionImpl |
-      | checkpoint | threads: 1    | threads   | foo.smk | 1     | SmkRuleOrCheckpointArgsSectionImpl |
+      | rule_like  | text           | section   | file    | times | class                              |
+      | rule       | output: ""     | output    | foo.smk | 1     | SmkRuleOrCheckpointArgsSectionImpl |
+      | rule       | input: ""      | input     | foo.smk | 1     | SmkRuleOrCheckpointArgsSectionImpl |
+      | rule       | params: ""     | params    | foo.smk | 1     | SmkRuleOrCheckpointArgsSectionImpl |
+      | rule       | log: ""        | log       | foo.smk | 1     | SmkRuleOrCheckpointArgsSectionImpl |
+      | rule       | resources: ""  | resources | foo.smk | 1     | SmkRuleOrCheckpointArgsSectionImpl |
+      | rule       | version: ""    | version   | foo.smk | 1     | SmkRuleOrCheckpointArgsSectionImpl |
+      | rule       | threads: 1     | threads   | foo.smk | 1     | SmkRuleOrCheckpointArgsSectionImpl |
+      | rule       | handover: True | handover  | foo.smk | 1     | SmkRuleOrCheckpointArgsSectionImpl |
+      | checkpoint | output: ""     | output    | foo.smk | 1     | SmkRuleOrCheckpointArgsSectionImpl |
+      | checkpoint | threads: 1     | threads   | foo.smk | 1     | SmkRuleOrCheckpointArgsSectionImpl |
+      | checkpoint | handover: True | handover  | foo.smk | 1     | SmkRuleOrCheckpointArgsSectionImpl |
 
   Scenario Outline: Do not resolve to section in another rule, part1 (correct filters in SmkPyReferenceImpl)
     Given a snakemake project

--- a/src/test/resources/features/resolve/smkl_in_section_resolve.feature
+++ b/src/test/resources/features/resolve/smkl_in_section_resolve.feature
@@ -42,6 +42,7 @@ Feature: Resolve for sections/variables in SmkSL injections
          name: "new_rule_name"
          resources: a=""
          script: ""
+         handover: True
          shell: "{<section>}"
          run:
     """
@@ -65,6 +66,7 @@ Feature: Resolve for sections/variables in SmkSL injections
       | script               |
       | cache                |
       | name                 |
+      | handover             |
 
   Scenario Outline: Resolve for python specific variables for sections w/o arguments
       Given a <smk_vers> project

--- a/src/test/resources/features/stringLanguage/string_language_injection.feature
+++ b/src/test/resources/features/stringLanguage/string_language_injection.feature
@@ -187,6 +187,7 @@ Feature: Tests on snakemake string language injection
     | singularity          |
     | container            |
     | notebook             |
+    |handover              |
 
   Scenario Outline: Inject in snakemake function calls
     Given a snakemake project


### PR DESCRIPTION
Issue is resolved. Support for 'handover' sections is added. 'Completion', 'resolve' and code inspections were set according to 'handover' functional abilities.

![handover](https://user-images.githubusercontent.com/55440084/125035666-c46d1280-e09a-11eb-8682-83dba870968d.gif)
