### PR TITLE
Features/#454 keywords arguments highlighting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Released on ...
 - TODO  (see [#NNN](https://github.com/JetBrains-Research/snakecharm/issues/NNN)) 
 
 ### Fixed
+- Keyword arguments highlighting (see [#454](https://github.com/JetBrains-Research/snakecharm/issues/454))
 - Resolve for `rules` keyword if `snakemake` version less than `6.1` (see [#359](https://github.com/JetBrains-Research/snakecharm/issues/359))
 - TODO  (see [#NNN](https://github.com/JetBrains-Research/snakecharm/issues/NNN)) 
 

--- a/src/main/kotlin/com/jetbrains/snakecharm/lang/highlighter/SmkSyntaxAnnotator.kt
+++ b/src/main/kotlin/com/jetbrains/snakecharm/lang/highlighter/SmkSyntaxAnnotator.kt
@@ -97,15 +97,5 @@ object SmkSyntaxAnnotator : SmkAnnotator() {
         st.getSectionKeywordNode()?.let {
             addHighlightingAnnotation(it, SnakemakeSyntaxHighlighterFactory.SMK_DECORATOR)
         }
-        if (st is SmkArgsSection) {
-            st.keywordArguments?.forEach {
-                it.keywordNode?.psi?.let { name ->
-                    addHighlightingAnnotation(
-                        name,
-                        SnakemakeSyntaxHighlighterFactory.SMK_KEYWORD_ARGUMENT
-                    )
-                }
-            }
-        }
     }
 }

--- a/src/main/kotlin/com/jetbrains/snakecharm/lang/highlighter/SnakemakeSyntaxHighlighterFactory.kt
+++ b/src/main/kotlin/com/jetbrains/snakecharm/lang/highlighter/SnakemakeSyntaxHighlighterFactory.kt
@@ -33,10 +33,8 @@ class SnakemakeSyntaxHighlighterFactory : SyntaxHighlighterFactory() {
         )
         val SMK_PREDEFINED_DEFINITION: TextAttributesKey =
             PyHighlighter.PY_PREDEFINED_DEFINITION // IDK why, but explicit creating via '.createText...' works improperly
-        val SMK_KEYWORD_ARGUMENT = TextAttributesKey.createTextAttributesKey(
-            "SMK_KEYWORD_ARGUMENT",
-            DefaultLanguageHighlighterColors.PARAMETER
-        )
+        val SMK_KEYWORD_ARGUMENT: TextAttributesKey =
+            PyHighlighter.PY_KEYWORD_ARGUMENT // The same to SMK_PREDEFINED_DEFINITION case
         val SMK_TEXT = TextAttributesKey.createTextAttributesKey("SMK_TEXT", DefaultLanguageHighlighterColors.STRING)
         val SMK_TRIPLE_QUOTED_STRING = TextAttributesKey.createTextAttributesKey(
             "SMK_TRIPLE_QUOTED_STRING",

--- a/src/test/resources/features/highlighting/smk_syntax_annotator.feature
+++ b/src/test/resources/features/highlighting/smk_syntax_annotator.feature
@@ -222,21 +222,6 @@ Feature: Annotate additional syntax
     """
     When I check highlighting infos
 
-  Scenario: Annotate keyword argument
-    Given a snakemake project
-    Given I open a file "foo.smk" with text
-    """
-    rule NAME:
-        input:
-            "file1",
-            arg = "file2"
-    """
-    Then I expect inspection info on <arg> with message
-    """
-    SMK_KEYWORD_ARGUMENT
-    """
-    When I check highlighting infos ignoring extra highlighting
-
   Scenario: 'use' section highlighting, part 2
     Given a snakemake project
     Given I open a file "foo.smk" with text


### PR DESCRIPTION
Now keyword arguments use python highlighting key so all arguments have the same color.