### PR TITLE
Declare compatibility with PyCharm/IntelliJ 2026.1 (build 261) — VALIDATED NON-VIABLE, superseded by #570

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 
 # SnakeCharm Plugin Changelog
 
+## [2025.2.3]
+Released <Unreleased>
+
+### Plugin
+- Declared compatibility with PyCharm / IntelliJ Platform 2026.1 (build `261`) by raising `pluginUntilBuild` to `261.*` (built against PyCharm Community 2025.2, the last standalone Community release)
+
 ## [2025.2.2]
 Released <Unreleased>
 

--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -98,6 +98,14 @@ If you get `Unimplemented substep definition` in all `*.feature` files, ensure:
   * Check available IDE versions with
     `./gradlew printProductsReleases`, or query
     `https://data.services.jetbrains.com/products/releases?code=PY&type=release` (`PY`=PyCharm).
+  * **`./gradlew verifyPlugin` and `pluginUntilBuild`.** The `pluginVerification` block in
+    `build.gradle.kts` uses `recommended()`, which resolves the set of IDEs spanning
+    `pluginSinceBuild`..`pluginUntilBuild`. Once `pluginUntilBuild` is raised past `252`,
+    `recommended()` asks for PyCharm **Community** releases above 2025.2 (e.g.
+    `pycharm-community:2025.3`) that **do not exist** — Community ended at 2025.2 — so the task
+    fails at dependency resolution (`Could not find python:pycharm-community:2025.3`) before any
+    verification runs. To verify against 2026.1+, pin explicit Professional IDEs instead, e.g.
+    `ide(IntelliJPlatformType.PyCharmProfessional, "2026.1")`, and drop `recommended()`.
 * Update `snakemakeWrappersRepoVersion` to up-to-date, need to be updated on TeamCity CI as well.
  
 **Release plugin:**

--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -56,14 +56,20 @@ If Gradle can't auto-detect the JDK, pass it explicitly:
       -Didea.config.path=$PROJECT_DIR$/.sandbox_pycharm/config-test -Didea.system.path=$PROJECT_DIR$/.sandbox_pycharm/system-test -Didea.plugins.path=$PROJECT_DIR$/.sandbox_pycharm/plugins-test -Didea.force.use.core.classloader=true
       ```
 
-2. Checkout `snakemake` project sources and configure as test data:
+2. Checkout `snakemake` project sources and configure as test data. Use the version that
+   matches `defaultVersion` in `snakemake_api.yaml` (currently **9.9.0**) — otherwise the
+   `snakemake_api.yaml` FQN-resolution and completion/resolve feature tests fail. Modern
+   snakemake (9.x) uses a `src/` layout, so the symlink must point at `src/snakemake`:
     ```shell
     cd ~
     git clone https://github.com/snakemake/snakemake.git
+    git -C ~/snakemake checkout v9.9.0   # match snakemake_api.yaml defaultVersion
 
-    cd ./testData/MockPackages3
-    ln -s ~/snakemake/snakemake snakemake
+    cd <snakecharm>/testData/MockPackages3
+    ln -s ~/snakemake/src/snakemake snakemake   # 9.x src/ layout (older releases: ~/snakemake/snakemake)
     ```
+   After changing anything under the mock directories, delete the sandbox VFS cache before
+   re-running tests (e.g. `rm -rf .sandbox_pycharm`), per the note at the bottom of this file.
 
 Tests are written in [Gherkin](https://cucumber.io/docs/gherkin). You could run tests:
 * Using gradle `test` task

--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -15,6 +15,36 @@
 * Run `./gradlew buildPlugin`
 * Plugin bundle is located in ` build/distributions/snakecharm-*.zip`
 
+**Command-line build & test (no IDE required):**
+
+The Gradle build uses a **JDK 21 toolchain** (`javaVersion` in `gradle.properties`) and the
+Gradle version pinned in `gradle.properties` (`gradleVersion`). Make sure a JDK 21 is
+installed and visible to Gradle before building from the command line. For example:
+
+```shell
+# macOS (Homebrew): install a JDK 21
+brew install openjdk@21
+
+# Point Gradle at it for this build (or manage per-directory with jenv/asdf/SDKMAN):
+export JAVA_HOME=$(/usr/libexec/java_home -v 21)
+
+./gradlew clean buildPlugin        # builds build/distributions/snakecharm-*.zip
+./gradlew test                     # runs the JUnit + Cucumber test suite
+./gradlew verifyPlugin             # runs the IntelliJ Plugin Verifier
+./gradlew runIde                   # launches a sandbox IDE with the plugin installed
+```
+
+If Gradle can't auto-detect the JDK, pass it explicitly:
+`-Dorg.gradle.java.installations.paths=$JAVA_HOME`.
+
+> **Note on the target IDE.** `platformType`/`platformVersion` in `gradle.properties` select
+> the IDE the plugin is built and tested against; it is downloaded automatically on first
+> build (a multi-hundred-MB to ~1 GB download). Since PyCharm was unified in 2025.1 and the
+> standalone Community Edition ended at 2025.2/2025.3, releases from 2026.1 (build `261`) on
+> are distributed under the Professional artifact, so `platformType = PY` is required to
+> build against them. The free/Pro split is a runtime license state and does not affect the
+> downloaded SDK or building the plugin.
+
 
 **Configure Tests:**
         
@@ -52,6 +82,16 @@ If you get `Unimplemented substep definition` in all `*.feature` files, ensure:
   * 
 * Update platform API and this plugin versions in `gradle.properties`, see `pluginVersion`, `pluginSinceBuild`, `pluginUntilBuild`, `platformVersion`
   * `pluginVersion` version should be also mentioned in changelog `CHANGELOG.md`
+  * Build numbers map to IDE versions per
+    [build-number-ranges](https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html),
+    e.g. `2025.2`=`252`, `2025.3`=`253`, `2026.1`=`261`. Set `pluginUntilBuild` to the
+    branch of the newest IDE you actually built/tested against (e.g. `261.*`).
+  * `platformType`: PyCharm Community (`PC`) ended at 2025.2/2025.3. From 2026.1 (`261`) on,
+    the unified PyCharm ships under the Professional artifact, so use `platformType = PY`
+    (the build wires `Pythonid` for `PY`/`PD` and `PythonCore` for `PC`).
+  * Check available IDE versions with
+    `./gradlew printProductsReleases`, or query
+    `https://data.services.jetbrains.com/products/releases?code=PY&type=release` (`PY`=PyCharm).
 * Update `snakemakeWrappersRepoVersion` to up-to-date, need to be updated on TeamCity CI as well.
  
 **Release plugin:**

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -188,15 +188,19 @@ intellijPlatform {
 
     pluginVerification {
         ides {
-            // releases based on since/until builds
-            recommended()
-            // EAP snapshots
-            select {
-                types = listOf(IntelliJPlatformType.PyCharmProfessional)
-                channels = listOf(ProductRelease.Channel.EAP, ProductRelease.Channel.RELEASE)
-                sinceBuild = "242"
-                untilBuild = "301.*"
-            }
+            // TEMP (local, do not commit): pin to 2026.1 Professional to get the 261 verdict.
+            // recommended() resolves pycharm-community:2025.3, which does not exist (Community
+            // ended at 2025.2), and aborts the whole task once pluginUntilBuild = 261.*.
+            ide(IntelliJPlatformType.PyCharmProfessional, "2026.1")
+//            // releases based on since/until builds
+//            recommended()
+//            // EAP snapshots
+//            select {
+//                types = listOf(IntelliJPlatformType.PyCharmProfessional)
+//                channels = listOf(ProductRelease.Channel.EAP, ProductRelease.Channel.RELEASE)
+//                sinceBuild = "242"
+//                untilBuild = "301.*"
+//            }
         }
     }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,7 +8,7 @@ pluginName = SnakeCharm
 #   * {pluginVersion}{pluginPreReleaseSuffix}
 #   * plugin version is YEAR.MAJOR.MINOR, where YEAR.MAJOR is a minimal compatible platform version, MINOR is version digit.
 #   * {pluginPreReleaseSuffix}: Use empty string [..=] for release, for eap: [..=-eap] or [..=-eap.2]
-pluginVersion = 2025.2.2
+pluginVersion = 2025.2.3
 pluginPreReleaseSuffix=-eap
 #pluginPreReleaseSuffix=
 
@@ -21,7 +21,7 @@ pluginBuildCounter=SNAPSHOT
 # See https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 # for insight into build numbers and IntelliJ Platform versions.
 pluginSinceBuild = 252
-pluginUntilBuild = 253.*
+pluginUntilBuild = 261.*
 org.jetbrains.intellij.platform.useCacheRedirector=false
 
 # Versions: 2021.1.1, LATEST-EAP-SNAPSHOT, LATEST-TRUNK-SNAPSHOT, 201-EAP-SNAPSHOT, 201.7223.69
@@ -42,6 +42,12 @@ platformPlugins =
 # -- PyCharm: --
 # * Run Snakemake plugin inside PyCharm. The IDE will be downloaded automatically
 # PC, PY
+# NB: 2025.2 was the final standalone PyCharm Community (PC) release; PyCharm was then
+#     unified into a single product (free core + paid Pro), and 2026.1+ (build 261+) is
+#     distributed only under the Professional artifact (PY). We still build against the
+#     last downloadable PyCharm Community release (2025.2 / 252) and declare compatibility
+#     up to 261.*; a full move to PY/2026.1 is a larger port (Python plugin restructured
+#     into v2 content modules, `ReturnAnnotator` removed) tracked on a separate branch.
 platformType = PC
 # 2021.1.1, 213-EAP-SNAPSHOT, LATEST-TRUNK-SNAPSHOT, LATEST-EAP-SNAPSHOT, 213.5281.17, 212.5457-EAP-CANDIDATE-SNAPSHOT
 # see: https://www.jetbrains.com/intellij-repository/snapshots/


### PR DESCRIPTION
> ❌ **Closing this PR — validation proves the metadata-only approach does not work on 2026.1.** Superseded by the source port in #570.

## What this tried

PyCharm / IntelliJ **2026.1** is build branch **`261`**, which the released `pluginUntilBuild = 253.*` excludes, so the plugin refuses to load on 2026.1. This PR took the low-risk path: raise the upper bound (`253.* → 261.*`, `pluginVersion → 2025.2.3`) while **still building against PyCharm Community 2025.2** (the last standalone Community release) — i.e. a metadata-only compatibility widening, **no source changes**. The premise was that the unchanged 2025.2 binary would simply *load* on 2026.1.

## Why it does not work (validated)

Ran the IntelliJ Plugin Verifier against **`PY-261.22158.340`** (PyCharm Professional 2026.1). The plugin compiles and the manifest would permit loading, but it hits **4 hard compatibility problems — all from a single class removed in 2026.1**, `com.jetbrains.python.validation.ReturnAnnotator`. Each reference throws **`NoSuchClassError` at runtime**:

```
Plugin SnakeCharm:2025.2.3-eap.SNAPSHOT against PY-261.22158.340: 4 compatibility problems
#Access to unresolved class com.jetbrains.python.validation.ReturnAnnotator
  - SnakemakeVisitorFilter.<init>()                → NoSuchClassError
  - SmkReturnAnnotator.visitPyReturnStatement(...) → NoSuchClassError
  - SmkReturnAnnotator (class)                     → NoSuchClassError
  - SmkReturnAnnotator.<init>()                    → NoSuchClassError
(+ 7 scheduled-for-removal, 4 deprecated incl. PyAnnotator, 155 experimental, 8 internal — not blockers)
```

So raising `pluginUntilBuild` alone would let the plugin **install on 2026.1 and then crash** when the annotator classes load — strictly worse than the current honest "incompatible with this version" rejection. The metadata-only widening is therefore **not viable**; a real source port is required (the `run:`/python-block "return outside function" suppression has to be rebuilt, since `ReturnAnnotator` is gone and the check moved into the `final`, internal `PySyntaxAnnotator`).

➡️ **The source port that actually builds against 2026.1 is #570** (branch `update-for-intellij-2026.1`; see `PORTING-2026.1.md`, which documents this `ReturnAnnotator` removal among ~37 API breaks, plus this verification).

## How to reproduce the verification

```shell
export JAVA_HOME=$(/usr/libexec/java_home -v 21)
./gradlew verifyPlugin -PsnakemakeWrappersRepoPath=testData/wrappers_storage
```

with `pluginVerification.ides` pinned to `ide(IntelliJPlatformType.PyCharmProfessional, "2026.1")` (committed on this branch). Two gotchas hit along the way:

- `recommended()` **cannot** be used to verify once `pluginUntilBuild > 252`: it resolves nonexistent `pycharm-community` releases above 2025.2 and aborts before verifying — pin an explicit Professional IDE instead (documented in `DEVELOPER.md`).
- `./gradlew verifyPlugin` / `buildPlugin` is blocked for outside contributors by a hardcoded `snakemakeWrappersRepoPath`, overridden above with the in-repo test data — tracked separately in #571.

The two validation commits on this branch (verifier pin + `DEVELOPER.md` note) are kept as a record.
