### PR TITLE
Don't require a hardcoded snakemakeWrappersRepoPath to build the plugin

### DIFF
--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -13,17 +13,17 @@
 
 **Build plugin from sources:**
 * Run `./gradlew buildPlugin`
-* Plugin bundle is located in ` build/distributions/snakecharm-*.zip`
+* Plugin bundle is located in `build/distributions/snakecharm-*.zip`
 * The bundled snakemake-wrappers metadata is optional for a local build: if
   `snakemakeWrappersRepoPath` is unset (the default), the `:buildWrappersBundle` task is
   skipped with a warning and the plugin is built without bundled wrappers — it runs normally,
   but wrapper name completion has nothing to offer. If the property *is* set and does not point
   at a wrappers checkout, the build still fails loudly rather than quietly shipping without them.
-  To include them,
-  point it at a local [snakemake-wrappers](https://github.com/snakemake/snakemake-wrappers)
+  To include them, point it at a local [snakemake-wrappers](https://github.com/snakemake/snakemake-wrappers)
   checkout whose content matches `snakemakeWrappersRepoVersion`:
-  `./gradlew buildPlugin -PsnakemakeWrappersRepoPath=/path/to/snakemake-wrappers`
-
+  `./gradlew buildPlugin -PsnakemakeWrappersRepoPath=/path/to/snakemake-wrappers`.
+  As an alternative, you could locally set `snakemakeWrappersRepoPath` to existing wrappers folder in 
+  `gradle.properties` file.
 
 **Configure Tests:**
         

--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -14,6 +14,12 @@
 **Build plugin from sources:**
 * Run `./gradlew buildPlugin`
 * Plugin bundle is located in ` build/distributions/snakecharm-*.zip`
+* The bundled snakemake-wrappers metadata is optional for a local build: if
+  `snakemakeWrappersRepoPath` is unset (the default), the `:buildWrappersBundle` task is
+  skipped with a warning and the plugin is built without bundled wrappers. To include them,
+  point it at a local [snakemake-wrappers](https://github.com/snakemake/snakemake-wrappers)
+  checkout whose content matches `snakemakeWrappersRepoVersion`:
+  `./gradlew buildPlugin -PsnakemakeWrappersRepoPath=/path/to/snakemake-wrappers`
 
 
 **Configure Tests:**

--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -16,7 +16,10 @@
 * Plugin bundle is located in ` build/distributions/snakecharm-*.zip`
 * The bundled snakemake-wrappers metadata is optional for a local build: if
   `snakemakeWrappersRepoPath` is unset (the default), the `:buildWrappersBundle` task is
-  skipped with a warning and the plugin is built without bundled wrappers. To include them,
+  skipped with a warning and the plugin is built without bundled wrappers — it runs normally,
+  but wrapper name completion has nothing to offer. If the property *is* set and does not point
+  at a wrappers checkout, the build still fails loudly rather than quietly shipping without them.
+  To include them,
   point it at a local [snakemake-wrappers](https://github.com/snakemake/snakemake-wrappers)
   checkout whose content matches `snakemakeWrappersRepoVersion`:
   `./gradlew buildPlugin -PsnakemakeWrappersRepoPath=/path/to/snakemake-wrappers`

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -275,8 +275,25 @@ tasks {
                 configurations[Configurations.INTELLIJ_PLATFORM_TEST_CLASSPATH]
         enableAssertions = true
 
+        // The production wrappers bundle needs a local snakemake-wrappers checkout (see DEVELOPER.md);
+        // CI provides one. When it's unset/missing, skip with a warning instead of failing
+        // buildPlugin/verifyPlugin for contributors who don't have it. See issue #571.
+        val wrappersRepoPath = gradlePropertyOptional("snakemakeWrappersRepoPath")
+        val wrappersRepoDir = wrappersRepoPath?.takeIf { it.isNotBlank() }?.let { project.file(it) }
+        onlyIf {
+            val exists = wrappersRepoDir?.exists() == true
+            if (!exists) {
+                logger.warn(
+                    "buildWrappersBundle: snakemakeWrappersRepoPath '${wrappersRepoPath ?: ""}' not found; " +
+                        "skipping wrappers bundle (the built plugin will omit bundled wrappers). " +
+                        "Pass -PsnakemakeWrappersRepoPath=<snakemake-wrappers checkout> to include them. See #571."
+                )
+            }
+            exists
+        }
+
         args(
-            gradleProperty("snakemakeWrappersRepoPath").get(),
+            wrappersRepoPath ?: "",
             gradleProperty("snakemakeWrappersRepoVersion").get(),
             layout.buildDirectory.file("bundledWrappers/smk-wrapper-storage-bundled.cbor").get(),
             layout.projectDirectory.file("snakemake_api.yaml")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -276,20 +276,27 @@ tasks {
         enableAssertions = true
 
         // The production wrappers bundle needs a local snakemake-wrappers checkout (see DEVELOPER.md);
-        // CI provides one. When it's unset/missing, skip with a warning instead of failing
+        // CI provides one. When the property is unset, skip with a warning instead of failing
         // buildPlugin/verifyPlugin for contributors who don't have it. See issue #571.
-        val wrappersRepoPath = gradlePropertyOptional("snakemakeWrappersRepoPath")
-        val wrappersRepoDir = wrappersRepoPath?.takeIf { it.isNotBlank() }?.let { project.file(it) }
+        //
+        // Skip only when it is *unset*. If it is set but wrong (a typo, or a renamed CI checkout) the
+        // task still runs and SmkWrapperCrawler fails loudly, as before -- silently publishing a plugin
+        // with no wrapper metadata is a much worse outcome than a broken build.
+        val wrappersRepoPath = gradlePropertyOptional("snakemakeWrappersRepoPath")?.takeIf { it.isNotBlank() }
+        val wrappersBundleFile = layout.buildDirectory.file("bundledWrappers/smk-wrapper-storage-bundled.cbor")
         onlyIf {
-            val exists = wrappersRepoDir?.exists() == true
-            if (!exists) {
+            if (wrappersRepoPath == null) {
                 logger.warn(
-                    "buildWrappersBundle: snakemakeWrappersRepoPath '${wrappersRepoPath ?: ""}' not found; " +
-                        "skipping wrappers bundle (the built plugin will omit bundled wrappers). " +
+                    "buildWrappersBundle: snakemakeWrappersRepoPath is not set; " +
+                        "skipping wrappers bundle (the built plugin will omit bundled wrappers, so wrapper " +
+                        "name completion will be unavailable). " +
                         "Pass -PsnakemakeWrappersRepoPath=<snakemake-wrappers checkout> to include them. See #571."
                 )
+                // Drop a bundle left by an earlier run that did have the property, so prepareSandbox
+                // cannot pack a stale one whose embedded repo version disagrees with gradle.properties.
+                wrappersBundleFile.get().asFile.delete()
             }
-            exists
+            wrappersRepoPath != null
         }
 
         args(

--- a/gradle.properties
+++ b/gradle.properties
@@ -62,7 +62,7 @@ platformVersion = 2025.2
 # Custom path to PyCharm installer:
 # * see https://plugins.jetbrains.com/docs/intellij/tools-gradle-intellij-plugin.html#intellij-extension-localpath
 # * if is set, then 'platformVersion' is ignored
-#platformLocalPath=/Users/romeo/work/idea_related/snapshots/PyCharm_CE_2023.2_EAP_232.8660.app/Contents
+#platformLocalPath=/path/to/PyCharm.app/Contents
 
 pythonPlugin =
 
@@ -106,4 +106,10 @@ gradleVersion = 8.13
 
 # * To checkout tag run: `git tag -l; TAG=3.8.0; git checkout tags/v$TAG -b tags/$TAG` (git checkout tags/v1.3.2 -b tags/v1.3.2)
 snakemakeWrappersRepoVersion=v7.2.0
-snakemakeWrappersRepoPath=/Users/romeo/work/git_repos/snakecharm_related/snakemake-wrappers
+# Local path to a snakemake-wrappers checkout (content matching snakemakeWrappersRepoVersion above)
+# that the :buildWrappersBundle task reads to bundle wrapper metadata into the distributable plugin.
+# Unset by default: contributors don't need it -- the task skips with a warning and the plugin still
+# builds (without bundled wrappers; tests use testData/wrappers_storage instead). To include them:
+#   ./gradlew buildPlugin -PsnakemakeWrappersRepoPath=/path/to/snakemake-wrappers
+# CI (TeamCity) supplies this from its snakemake-wrappers VCS-root checkout. See issue #571.
+#snakemakeWrappersRepoPath=/path/to/snakemake-wrappers

--- a/src/main/kotlin/com/jetbrains/snakecharm/codeInsight/completion/wrapper/SmkWrapperStorage.kt
+++ b/src/main/kotlin/com/jetbrains/snakecharm/codeInsight/completion/wrapper/SmkWrapperStorage.kt
@@ -2,6 +2,7 @@ package com.jetbrains.snakecharm.codeInsight.completion.wrapper
 
 import com.intellij.openapi.Disposable
 import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.progress.ProgressIndicator
 import com.intellij.openapi.progress.ProgressManager
 import com.intellij.openapi.progress.Task
@@ -134,6 +135,8 @@ class SmkWrapperStorage(val project: Project) : Disposable {
     )
 
     companion object {
+        private val LOGGER = Logger.getInstance(SmkWrapperStorage::class.java)
+
         fun getInstance(project: Project) = project.getService(SmkWrapperStorage::class.java)!!
 
         @ExperimentalSerializationApi
@@ -200,8 +203,16 @@ class SmkWrapperStorage(val project: Project) : Disposable {
         private fun loadBundledWrappers(storage: SmkWrapperStorage) {
             val pluginSandboxPath = SnakemakePluginUtil.getPluginSandboxPath(SmkWrapperStorage::class.java)
             val wrappersBundlePath = pluginSandboxPath.resolve("extra/smk-wrapper-storage-bundled.cbor")
-            requireNotNull(!wrappersBundlePath.exists()) {
-                "Missing wrappers bundle in plugin bundle: '$wrappersBundlePath' doesn't exist"
+            if (!wrappersBundlePath.exists()) {
+                // A plugin built without `-PsnakemakeWrappersRepoPath` has no bundle (see #571), which is
+                // now the default for a local build. Degrade to "no wrappers known" instead of throwing
+                // out of the background wrapper-collection task.
+                LOGGER.warn(
+                    "Missing wrappers bundle in plugin bundle: '$wrappersBundlePath' doesn't exist. " +
+                            "Wrapper name completion will be unavailable."
+                )
+                storage.initFrom("", emptyList())
+                return
             }
             val (repoVersion, wrappers) = deserializeWrappers(wrappersBundlePath)
             storage.initFrom(repoVersion, wrappers)


### PR DESCRIPTION
Fixes #571.

## Problem

`gradle.properties` shipped a hardcoded, machine-specific default for `snakemakeWrappersRepoPath` pointing at a JetBrains developer's home directory:

```properties
snakemakeWrappersRepoPath=/Users/romeo/work/git_repos/snakecharm_related/snakemake-wrappers
```

Because that path doesn't exist on anyone else's machine, `./gradlew buildPlugin` (and `verifyPlugin`) failed for every outside contributor at `:buildWrappersBundle`:

```
Wrappers src folder doesn't exist: [/Users/romeo/work/git_repos/snakecharm_related/snakemake-wrappers]
> Execution failed for task ':buildWrappersBundle'.
```

`./gradlew test` was unaffected — it uses `buildTestWrappersBundle` with the in-repo `testData/wrappers_storage` — so only the distributable-ZIP path was broken.

## Fix

Make the production wrappers bundle **optional** for local builds, while leaving CI behaviour unchanged.

- **`build.gradle.kts`** — `:buildWrappersBundle` skips with an actionable warning when `snakemakeWrappersRepoPath` is **unset**, instead of passing a nonexistent path to `SmkWrapperCrawler` and failing the build. It deliberately does *not* skip when the property is set but wrong: a typo or a renamed TeamCity VCS root still fails loudly, because `prepareSandbox` copies the `.cbor` with a plain `from()` and Gradle's `Copy` silently ignores a missing source — so a "helpful" skip there would publish a plugin with no wrapper metadata and only a warning in the log. The skip path also deletes any bundle left by an earlier run, so a rebuild after bumping `snakemakeWrappersRepoVersion` can't quietly ship a stale one.

- **`gradle.properties`** — drop the hardcoded path; the property is now unset by default and documented, with the `-PsnakemakeWrappersRepoPath=<checkout>` override. CI (TeamCity) still supplies a real path from its `snakemake-wrappers` VCS root. Also genericised the commented machine-specific `platformLocalPath` example.

- **`SmkWrapperStorage.kt`** — make the runtime side survive what the build side now allows. The guard for a missing bundle could never fire: `requireNotNull(!wrappersBundlePath.exists()) { ... }` cannot throw (the value is non-null either way) and the condition is inverted besides, so execution fell through to `Files.readAllBytes` and raised `NoSuchFileException` from the background "collecting wrappers" task. That was unreachable while every build bundled wrappers; it stops being unreachable here, since `useBundledWrappersInfo` defaults to `true` and a locally built plugin now legitimately has no bundle. It now warns and initialises empty storage.

- **`DEVELOPER.md`** — note that `buildPlugin` works without a wrappers checkout, what that costs (wrapper name completion has nothing to offer), and that a path which *is* set but wrong still fails the build.

## Verification

**What actually lands in the plugin.** `prepareSandbox` is what copies the bundle into `<plugin>/extra/`, so the two states are directly observable:

```
$ ./gradlew prepareSandbox                                              # property unset
> Task :buildWrappersBundle SKIPPED
$ ls .sandbox_pycharm/PC-2025.2/plugins/snakecharm/extra/
snakemake_api.yaml

$ ./gradlew prepareSandbox -PsnakemakeWrappersRepoPath=testData/wrappers_storage
$ ls .sandbox_pycharm/PC-2025.2/plugins/snakecharm/extra/
smk-wrapper-storage-bundled.cbor
snakemake_api.yaml
```

**Property unset** — task skips, warning is actionable, stale bundle removed:

```
> Task :buildWrappersBundle SKIPPED
buildWrappersBundle: snakemakeWrappersRepoPath is not set; skipping wrappers bundle (the built
plugin will omit bundled wrappers, so wrapper name completion will be unavailable). Pass
-PsnakemakeWrappersRepoPath=<snakemake-wrappers checkout> to include them. See #571.
BUILD SUCCESSFUL in 3s
```

**Property set but wrong** — still a hard failure, as before this PR:

```
$ ./gradlew buildWrappersBundle -PsnakemakeWrappersRepoPath=/tmp/definitely-not-here
Exception in thread "main" java.lang.IllegalArgumentException:
    Wrappers src folder doesn't exist: [/tmp/definitely-not-here]
BUILD FAILED in 2s
```

**Empty wrappers storage is safe for every consumer** — checked each one rather than assuming: `SmkWrapperCompletionProvider` and `SmkWrapperArgsCompletionProvider` iterate the list (no elements added), `SmkWrapperMissedArgumentsInspection` does `wrappers.find { … } ?: return` (no-op), and `SmkWrapperDocumentation` filters to `firstOrNull()` (no doc shown). None of them assume a non-empty list, so a wrapper-less build degrades to "wrapper features do nothing" rather than erroring.

## TODO for maintainers
- [ ] **Confirm the TeamCity configurations pass `-PsnakemakeWrappersRepoPath`.** This is the one thing I can't check from outside. The property no longer has a value in `gradle.properties`, so any configuration that relied on the file's default rather than passing its own would now produce a plugin with no wrapper metadata instead of failing. (The old default pointed at a personal laptop path, so realistically nothing could have depended on it — but a release is the wrong place to find out.)
- [ ] **Decide whether `publishPlugin` should hard-require the bundle.** The skip is right for `buildPlugin` on a contributor's machine and arguably wrong for a release. A guard on `publishPlugin` (fail if `build/bundledWrappers/smk-wrapper-storage-bundled.cbor` is absent) would make "released without wrappers" impossible rather than merely unlikely.
- [ ] **Confirm the approach.** This PR skips gracefully when the property is unset. The alternative is to keep failing and require an explicit opt-out (e.g. `-PskipWrappersBundle`), which is noisier for contributors but makes every wrapper-less build deliberate.

## Notes
Independent of #574, #576 and #573 — verified to merge cleanly against each. #576 touches the same file as the `SmkWrapperStorage.kt` change here, but a different function (`loadBundledWrappersTestsMode`), so the two can land in either order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
