### PR TITLE
Add AGENTS.md, a build/test/architecture guide for coding agents

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,12 +37,13 @@ PyCharm Professional. Note that **2025.2 is the last standalone PyCharm Communit
 
 **Wrappers bundle:** `:buildWrappersBundle` reads `snakemakeWrappersRepoPath` (a local
 [snakemake-wrappers](https://github.com/snakemake/snakemake-wrappers) checkout) and runs as part of
-`prepareSandbox`, so it sits in front of `buildPlugin`, `runIde` **and** the test tasks. The property
-`snakemakeWrappersRepoPath` is unset by default in `gradle.properties` so the plugin bundle and local IDE
-run will not provide wrappers related completion and other features until the variable is set in properties
-or using cmdline like `./gradlew buildPlugin -PsnakemakeWrappersRepoPath=/path/to/snakemake-wrappers`. 
-The test-only bundle (`:buildTestWrappersBundle`, what `test` actually consumes) reads by default
-`testData/wrappers_storage` and needs no property. 
+`prepareSandbox`, so it sits in front of `buildPlugin`, `runIde` **and** the test tasks. That
+property is commented out in `gradle.properties` by default, so a plain `buildPlugin` / `runIde`
+yields a plugin without wrapper completion and the other wrapper-driven features; pass it explicitly
+to include them: `./gradlew buildPlugin -PsnakemakeWrappersRepoPath=/path/to/snakemake-wrappers` (on
+TeamCity it comes from the wrappers VCS root — see issue #571). The test-only bundle
+(`:buildTestWrappersBundle`, what `test` actually consumes) defaults to `testData/wrappers_storage`
+and needs no property.
 
 **CLI build memory:** if `:compileKotlin` dies with `OutOfMemoryError: GC overhead limit exceeded`,
 give the Kotlin daemon more heap — append `-Pkotlin.daemon.jvmargs=-Xmx4g` (transforming some large
@@ -56,9 +57,9 @@ through a single JUnit runner, `AllCucumberFeaturesTest` (glue/step definitions 
 
 - **Run one feature:** add a `@here` tag above its `Feature:` line (or above a single `Scenario:` /
   `Scenario Outline:`) and set `tags = "not @ignore and @here"` in `AllCucumberFeaturesTest.kt`;
-  revert both afterwards. Once #577 lands, the runner edit is unnecessary — `test` forwards
-  `CUCUMBER_TAGS='@here'` to cucumber's `cucumber.filter.tags`, which overrides the annotation. Worth
-  the trouble either way: it turns a 25-minute suite into a ~60-second one.
+  revert both afterwards. If PR #577 lands, the runner edit becomes unnecessary — `test` there
+  forwards `CUCUMBER_TAGS='@here'` to cucumber's `cucumber.filter.tags`, which overrides the
+  annotation. Worth the trouble either way: it turns a 25-minute suite into a ~60-second one.
 - **Scenarios share one project.** The light fixture's descriptor is cached (it has to be on 2026.2 —
   a per-scenario mock SDK collides on symbolic id), so project *services* survive into the next
   scenario. A step that wants project state — framework enabled/disabled, settings, SDK — must set it
@@ -75,15 +76,17 @@ through a single JUnit runner, `AllCucumberFeaturesTest` (glue/step definitions 
   absent on a clean checkout — the *unversioned* `Given a snakemake project` scenarios (~135) then
   fail because `resolveQualifiedName("snakemake")` returns `[]`, while the checked-in per-version
   mocks (`MockPackages3_smk_<ver>`) still resolve. Provision it (see `DEVELOPER.md` → Configure Tests,
-  step 2): symlink` snakemake` to **`src/snakemake`** (https://github.com/snakemake/snakemake, checkout
-  desired version using repo tags) to `testData/MockPackages3/snakemake`. 
-  **Two traps that make a correct fixture look like it does nothing:** the version must match
-  `snakemake_api.yaml`'s `defaultVersion` (e.g. 9.9.0), and the test IDE
-  sandbox persists a VFS/index under `.sandbox_pycharm/<ide>/system-test/` that **`cleanTest` doesn't
-  clear** — if you add the fixture after a prior run, `rm -rf .sandbox_pycharm/*/system-test` once. If
-  you see a wall of `snakemake`-resolution failures on a fresh checkout, suspect this fixture, **not**
-  your change. (Full write-up: PR #574.)
-- **Analyzing results:** the full suite is large (~3200 scenarios; a full `test` run takes a while —
+  step 2): point `testData/MockPackages3/snakemake` at the `src/snakemake` package of a
+  [snakemake](https://github.com/snakemake/snakemake) checkout, at the release tag you want.
+  **Two traps that make a correct fixture look like it does nothing:** the checkout must be at the
+  version `snakemake_api.yaml` declares as `defaultVersion` (currently 9.9.0), and the test IDE
+  sandbox persists a VFS/index under `.sandbox_pycharm/**/system-test/` that **`cleanTest` doesn't
+  clear** — after adding the fixture to an already-tested checkout, remove it once with
+  `find .sandbox_pycharm -maxdepth 3 -name system-test -exec rm -rf {} +` (its depth varies with
+  how the tests were launched, so a fixed glob can silently match nothing). If you see a wall of
+  `snakemake`-resolution failures on a fresh checkout, suspect this fixture, **not** your change.
+  (Full write-up: PR #574.)
+- **Analyzing results:** the full suite is large (~3400 scenarios; a full `test` run takes a while —
   prefer the single-feature `@here` recipe while iterating). To triage or diff failures, parse
   `build/test-results/test/TEST-*.xml`: each `<testcase>` with a `<failure>`/`<error>` child is a
   failing scenario (name = `<feature> > <scenario> [#example]`).
@@ -104,15 +107,16 @@ Two languages, both layered onto the Python plugin:
    `"results/sample_{genome}.bam"`. Lives under `stringLanguage/`, lexer generated from
    `stringLanguage/lang/parser/smk_sl.flex` (JFlex), injected into Python string literals.
 
-SnakemCharm plugin features are based on the sources of the snakemake project 
-(https://github.com/snakemake/snakemake) so the plugin tries to do maximum static analysis of the underlying 
-snakemake python code. Due to the highly dynamic implementation of a snakemake framework the SnakeCharm 
-provides API descriptions of the implicit python api available in different blocks of Snakemake DSL. 
-Additionally, API changes among different snakemake versions, so snakemake version is considered 
-as `language level`. File `snakemake_api.yaml` (loaded by SnakemakeApiYamlAnnotationsService into project level
-`com.jetbrains.snakecharm.codeInsight.SnakemakeApiService` service class) describes API changes among 
-different snakemake versions. Key `defaultVersion` (e.g. 9.9.0) sets the default language level for the new 
- projects, and it is the latest language level officially supported by the plugin.
+Plugin features are derived from the sources of the
+[snakemake project](https://github.com/snakemake/snakemake), so SnakeCharm does as much static
+analysis of the underlying snakemake Python code as it can. Because the framework itself is highly
+dynamic, the plugin additionally ships descriptions of the implicit Python API available in each
+block of the Snakemake DSL. That API changes between snakemake releases, so the snakemake version is
+treated as a **language level**: `snakemake_api.yaml` at the repo root (loaded by
+`SnakemakeApiYamlAnnotationsService` into the project-level
+`com.jetbrains.snakecharm.codeInsight.SnakemakeApiService`) records the differences between
+versions. Its `defaultVersion` key (currently 9.9.0) is the language level new projects get, and the
+latest one the plugin officially supports.
 
 Feature areas (each maps to a source package and a `features/` test dir):
 
@@ -123,7 +127,8 @@ Feature areas (each maps to a source package and a `features/` test dir):
   "runtime magic" symbols (`expand`, `temp`, `config`, `rules`, …) are built by
   `SmkImplicitPySymbolsProvider`, which resolves them by qualified name against the project SDK's
   snakemake package.
-- `inspections/` — ~56 local inspections for common Snakemake mistakes.
+- `inspections/` — ~45 local inspections (`<localInspection>` entries in `plugin.xml`) for common
+  Snakemake mistakes.
 - `framework/` — Snakemake framework detection: locating the `snakemake` package via the project
   SDK / package manager, which gates most features and drives version-specific behaviour.
 - `lang/structureView/`, `lang/documentation/`, `lang/formatter/`, `spellchecker/`, `actions/` —

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,7 +37,8 @@ PyCharm Professional. Note that **2025.2 is the last standalone PyCharm Communit
 
 **Wrappers bundle:** `:buildWrappersBundle` reads `snakemakeWrappersRepoPath` (a local
 [snakemake-wrappers](https://github.com/snakemake/snakemake-wrappers) checkout) and runs as part of
-`prepareSandbox`, so it sits in front of `buildPlugin`, `runIde` **and** the test tasks. That
+`prepareSandbox`, so it sits in front of `buildPlugin` and `runIde` — but **not** the test tasks,
+which route through `prepareTestSandbox` and the separate test bundle below. That
 property is commented out in `gradle.properties` by default, so a plain `buildPlugin` / `runIde`
 yields a plugin without wrapper completion and the other wrapper-driven features; pass it explicitly
 to include them: `./gradlew buildPlugin -PsnakemakeWrappersRepoPath=/path/to/snakemake-wrappers` (on

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -60,12 +60,19 @@ through a single JUnit runner, `AllCucumberFeaturesTest` (glue/step definitions 
   revert both afterwards. If PR #577 lands, the runner edit becomes unnecessary — `test` there
   forwards `CUCUMBER_TAGS='@here'` to cucumber's `cucumber.filter.tags`, which overrides the
   annotation. Worth the trouble either way: it turns a 25-minute suite into a ~60-second one.
-- **Scenarios share one project.** The light fixture's descriptor is cached (it has to be on 2026.2 —
-  a per-scenario mock SDK collides on symbolic id), so project *services* survive into the next
-  scenario. A step that wants project state — framework enabled/disabled, settings, SDK — must set it
-  explicitly; it cannot rely on a fresh project's defaults. `Given a snakemake with disabled framework
-  project` broke exactly this way, and the scenario that depended on it stayed green for years only
-  because a second bug happened to cancel it out.
+- **Scenario isolation is thinner than it looks.** Every scenario asks IntelliJ's light-fixture
+  framework for a test project by handing it a `LightProjectDescriptor` — the object that says
+  which Python SDK and library roots the project needs. The framework hands back the *same* project
+  as long as it is given the same descriptor, and rebuilds it when the descriptor changes. On `master`
+  `StepDefs` constructs a fresh descriptor per scenario, so scenarios are mostly insulated from each
+  other by accident. #577 has to cache descriptors instead — on 2026.2 an SDK is a workspace-model
+  entity, so building a second mock SDK with the same name logs "symbolic id already exists", which
+  `TestLoggerFactory` turns into ~1070 failed scenarios. Once the project is shared, everything held
+  by a project-level *service* — framework enabled/disabled, settings, the configured SDK — survives
+  into the next scenario. **Write steps that set the project state they need rather than assume a
+  fresh project's defaults.** `Given a snakemake with disabled framework project` is the cautionary
+  example: it never disabled anything, it only skipped the enabling, and it passed for years purely
+  because each scenario used to start from a clean project.
 - **`testData` is NOT a declared input of the `test` task.** After editing any feature or
   test-data file, run `./gradlew cleanTest test` — plain `test` may serve stale cached results.
 - Test data lives in `testData/`. Snakemake API is mocked per-version under
@@ -86,8 +93,9 @@ through a single JUnit runner, `AllCucumberFeaturesTest` (glue/step definitions 
   how the tests were launched, so a fixed glob can silently match nothing). If you see a wall of
   `snakemake`-resolution failures on a fresh checkout, suspect this fixture, **not** your change.
   (Full write-up: PR #574.)
-- **Analyzing results:** the full suite is large (~3400 scenarios; a full `test` run takes a while —
-  prefer the single-feature `@here` recipe while iterating). To triage or diff failures, parse
+- **Analyzing results:** the suite is large — ~3250 Cucumber scenarios plus ~170 plain JUnit tests,
+  around 25 minutes for a full `test` run, so prefer the single-feature `@here` recipe while
+  iterating. To triage or diff failures, parse
   `build/test-results/test/TEST-*.xml`: each `<testcase>` with a `<failure>`/`<error>` child is a
   failing scenario (name = `<feature> > <scenario> [#example]`).
 
@@ -156,11 +164,11 @@ the entry class for any feature is to grep that file.
   platform's bytecode target (2026.2 emits Java 25, so javac 21 reports "bad class file … wrong
   version 69.0"); and the **`intelliJPlatform` gradle-plugin version** decides whether the Python
   plugin's v2 content modules load *in tests* at all (2.16.0 → 2.18.1 took one port from 3361 failing
-  scenarios to 1153). Check all three before debugging your own code.
+  tests, of ~3400, down to 1153). Check all three before debugging your own code.
 - **Logged errors are test failures.** `TestLoggerFactory` promotes anything logged at error level to
   a failed scenario, so one benign platform log can fail hundreds of unrelated tests. When triaging a
   wall of failures, group by exception message first — it is usually one cause, not many.
-- **Platform-bump gotcha:** since 2025.2+ the platform is modular — APIs, inspections, and extension
+- **Platform-bump gotcha:** since 2025.2 the platform is modular — APIs, inspections, and extension
   points that used to live in *core* have been split into separate modules / bundled plugins with
   their own classloaders. If a class or EP that worked before goes missing after a bump (often only
   visible in tests), declare it explicitly with `bundledModule("…")` / `bundledPlugin("…")` in

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,7 +18,10 @@ The Gradle build uses a **JDK 21 toolchain** (`javaVersion` in `gradle.propertie
 version pinned there (`gradleVersion`). **Launch Gradle itself with JDK 21**, not just as an
 available toolchain — the pinned Gradle can crash under a much newer JVM with a cryptic error
 (Gradle 8.x on JDK 24 fails with `Type T not present`). Set `JAVA_HOME` to a JDK 21 before building
-from the CLI (e.g. `export JAVA_HOME=$(/usr/libexec/java_home -v 21)`, or a jenv/asdf/SDKMAN shim).
+from the CLI and **verify it** with `"$JAVA_HOME/bin/java" -version`: on macOS
+`/usr/libexec/java_home -v 21` treats 21 as a *minimum*, so with no JDK 21 installed it returns a
+newer JDK, exits 0, and you get the Gradle crash above with no hint why. Use a jenv/asdf/SDKMAN path
+(`jenv prefix 21`) or an explicit install path.
 
 ```shell
 ./gradlew buildPlugin      # -> build/distributions/snakecharm-*.zip

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,12 +50,16 @@ through a single JUnit runner, `AllCucumberFeaturesTest` (glue/step definitions 
   cucumber steps select one via `Given a snakemake:<version> project`. Only the API files that
   differ between versions are copied into each mock (see `DEVELOPER.md` → Testdata).
 - **Fresh-checkout gotcha (saves hours):** `testData/MockPackages3/snakemake` is **gitignored** and
-  absent on a clean checkout — you must clone the snakemake repo and symlink it there (see
-  `DEVELOPER.md` → Configure Tests, step 2). Without it, a large batch (~100+) of resolve/completion
-  scenarios for the *unversioned* `snakemake` project fail — `resolveQualifiedName("snakemake")`
-  returns `[]` — while the checked-in per-version mocks (`MockPackages3_smk_<ver>`) still resolve. If
-  you see a wall of `snakemake`-resolution failures on a fresh checkout, suspect this missing
-  fixture, **not** your change.
+  absent on a clean checkout — the *unversioned* `Given a snakemake project` scenarios (~135) then
+  fail because `resolveQualifiedName("snakemake")` returns `[]`, while the checked-in per-version
+  mocks (`MockPackages3_smk_<ver>`) still resolve. Provision it (see `DEVELOPER.md` → Configure Tests,
+  step 2): symlink snakemake **9.9.0**'s **`src/snakemake`** (modern `src/` layout) to
+  `testData/MockPackages3/snakemake`. **Two traps that make a correct fixture look like it does
+  nothing:** the version must match `snakemake_api.yaml`'s `defaultVersion` (9.9.0), and the test IDE
+  sandbox persists a VFS/index under `.sandbox_pycharm/<ide>/system-test/` that **`cleanTest` doesn't
+  clear** — if you add the fixture after a prior run, `rm -rf .sandbox_pycharm/*/system-test` once. If
+  you see a wall of `snakemake`-resolution failures on a fresh checkout, suspect this fixture, **not**
+  your change. (Full write-up: PR #574.)
 - **Analyzing results:** the full suite is large (~3200 scenarios; a full `test` run takes a while —
   prefer the single-feature `@here` recipe while iterating). To triage or diff failures, parse
   `build/test-results/test/TEST-*.xml`: each `<testcase>` with a `<failure>`/`<error>` child is a

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -123,6 +123,18 @@ the entry class for any feature is to grep that file.
   [build-number-ranges](https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html)
   (`2025.2`=`252`, `2026.1`=`261`, …). `DEVELOPER.md` → "Update to new Platform API" is the
   checklist for a platform bump.
+- **A platform bump moves more than `platformVersion`.** Three toolchain baselines can move with it,
+  and each fails *before* your source is even considered, with an error that doesn't name the cause:
+  the **Kotlin compiler** must be new enough to read the platform's metadata (a compiler reads
+  metadata at most one minor above itself — 2026.2 ships metadata 2.4, so Kotlin 2.2 fails with
+  "compiled with an incompatible version of Kotlin"); the **Java toolchain** must match the
+  platform's bytecode target (2026.2 emits Java 25, so javac 21 reports "bad class file … wrong
+  version 69.0"); and the **`intelliJPlatform` gradle-plugin version** decides whether the Python
+  plugin's v2 content modules load *in tests* at all (2.16.0 → 2.18.1 took one port from 3361 failing
+  scenarios to 1153). Check all three before debugging your own code.
+- **Logged errors are test failures.** `TestLoggerFactory` promotes anything logged at error level to
+  a failed scenario, so one benign platform log can fail hundreds of unrelated tests. When triaging a
+  wall of failures, group by exception message first — it is usually one cause, not many.
 - **Platform-bump gotcha:** since 2025.2+ the platform is modular — APIs, inspections, and extension
   points that used to live in *core* have been split into separate modules / bundled plugins with
   their own classloaders. If a class or EP that worked before goes missing after a bump (often only

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,8 +15,11 @@ than defining a language from scratch.
 ## Build & test
 
 The Gradle build uses a **JDK 21 toolchain** (`javaVersion` in `gradle.properties`) and the Gradle
-version pinned there (`gradleVersion`). Ensure a JDK 21 is visible to Gradle before building from
-the CLI (e.g. `export JAVA_HOME=$(/usr/libexec/java_home -v 21)`, or a jenv/asdf/SDKMAN shim).
+version pinned there (`gradleVersion`). **Launch Gradle itself with JDK 21**, not just as an
+available toolchain — the pinned Gradle can crash under a much newer JVM with a cryptic error
+(Gradle 8.x on JDK 24 fails with `Type T not present`). Set `JAVA_HOME` to a JDK 21 before building
+from the CLI (e.g. `export JAVA_HOME=$(/usr/libexec/java_home -v 21)`, or a jenv/asdf/SDKMAN shim);
+`.java-version` also pins 21.
 
 ```shell
 ./gradlew buildPlugin      # -> build/distributions/snakecharm-*.zip

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,8 +54,17 @@ Tests are **Cucumber/Gherkin** feature files under `src/test/resources/features/
 through a single JUnit runner, `AllCucumberFeaturesTest` (glue/step definitions in
 `src/test/kotlin/features/glue/`). There is no per-feature test class.
 
-- **Run one feature:** add a `@here` tag above its `Feature:` line and set
-  `tags = "not @ignore and @here"` in `AllCucumberFeaturesTest.kt`; revert both afterwards.
+- **Run one feature:** add a `@here` tag above its `Feature:` line (or above a single `Scenario:` /
+  `Scenario Outline:`) and set `tags = "not @ignore and @here"` in `AllCucumberFeaturesTest.kt`;
+  revert both afterwards. Once #577 lands, the runner edit is unnecessary — `test` forwards
+  `CUCUMBER_TAGS='@here'` to cucumber's `cucumber.filter.tags`, which overrides the annotation. Worth
+  the trouble either way: it turns a 25-minute suite into a ~60-second one.
+- **Scenarios share one project.** The light fixture's descriptor is cached (it has to be on 2026.2 —
+  a per-scenario mock SDK collides on symbolic id), so project *services* survive into the next
+  scenario. A step that wants project state — framework enabled/disabled, settings, SDK — must set it
+  explicitly; it cannot rely on a fresh project's defaults. `Given a snakemake with disabled framework
+  project` broke exactly this way, and the scenario that depended on it stayed green for years only
+  because a second bug happened to cancel it out.
 - **`testData` is NOT a declared input of the `test` task.** After editing any feature or
   test-data file, run `./gradlew cleanTest test` — plain `test` may serve stale cached results.
 - Test data lives in `testData/`. Snakemake API is mocked per-version under

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,8 +18,7 @@ The Gradle build uses a **JDK 21 toolchain** (`javaVersion` in `gradle.propertie
 version pinned there (`gradleVersion`). **Launch Gradle itself with JDK 21**, not just as an
 available toolchain — the pinned Gradle can crash under a much newer JVM with a cryptic error
 (Gradle 8.x on JDK 24 fails with `Type T not present`). Set `JAVA_HOME` to a JDK 21 before building
-from the CLI (e.g. `export JAVA_HOME=$(/usr/libexec/java_home -v 21)`, or a jenv/asdf/SDKMAN shim);
-`.java-version` also pins 21.
+from the CLI (e.g. `export JAVA_HOME=$(/usr/libexec/java_home -v 21)`, or a jenv/asdf/SDKMAN shim).
 
 ```shell
 ./gradlew buildPlugin      # -> build/distributions/snakecharm-*.zip
@@ -30,10 +29,17 @@ from the CLI (e.g. `export JAVA_HOME=$(/usr/libexec/java_home -v 21)`, or a jenv
 
 The target IDE (`platformType`/`platformVersion` in `gradle.properties`) is downloaded
 automatically on first build (hundreds of MB). `platformType = PC` is PyCharm Community, `PY` is
-PyCharm Professional.
+PyCharm Professional. Note that **2025.2 is the last standalone PyCharm Community release** — from
+2026.1 (build 261) the unified PyCharm ships only under the `PY` artifact.
 
-Many test tasks need the wrappers repo path: append
-`-PsnakemakeWrappersRepoPath=testData/wrappers_storage`.
+**Wrappers bundle:** `:buildWrappersBundle` reads `snakemakeWrappersRepoPath` (a local
+[snakemake-wrappers](https://github.com/snakemake/snakemake-wrappers) checkout) and runs as part of
+`prepareSandbox`, so it sits in front of `buildPlugin`, `runIde` **and** the test tasks. The property
+is hardcoded to a JetBrains developer's absolute path in `gradle.properties`, so on any other machine
+those tasks fail until you override it — pointing it at the test fixture works:
+`-PsnakemakeWrappersRepoPath=testData/wrappers_storage` (issue #571 / PR #572 makes the task skip
+itself instead). The test-only bundle (`:buildTestWrappersBundle`, what `test` actually consumes)
+always reads `testData/wrappers_storage` and needs no property.
 
 **CLI build memory:** if `:compileKotlin` dies with `OutOfMemoryError: GC overhead limit exceeded`,
 give the Kotlin daemon more heap — append `-Pkotlin.daemon.jvmargs=-Xmx4g` (transforming some large

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,11 +38,11 @@ PyCharm Professional. Note that **2025.2 is the last standalone PyCharm Communit
 **Wrappers bundle:** `:buildWrappersBundle` reads `snakemakeWrappersRepoPath` (a local
 [snakemake-wrappers](https://github.com/snakemake/snakemake-wrappers) checkout) and runs as part of
 `prepareSandbox`, so it sits in front of `buildPlugin`, `runIde` **and** the test tasks. The property
-is hardcoded to a JetBrains developer's absolute path in `gradle.properties`, so on any other machine
-those tasks fail until you override it — pointing it at the test fixture works:
-`-PsnakemakeWrappersRepoPath=testData/wrappers_storage` (issue #571 / PR #572 makes the task skip
-itself instead). The test-only bundle (`:buildTestWrappersBundle`, what `test` actually consumes)
-always reads `testData/wrappers_storage` and needs no property.
+`snakemakeWrappersRepoPath` is unset by default in `gradle.properties` so the plugin bundle and local IDE
+run will not provide wrappers related completion and other features until the variable is set in properties
+or using cmdline like `./gradlew buildPlugin -PsnakemakeWrappersRepoPath=/path/to/snakemake-wrappers`. 
+The test-only bundle (`:buildTestWrappersBundle`, what `test` actually consumes) reads by default
+`testData/wrappers_storage` and needs no property. 
 
 **CLI build memory:** if `:compileKotlin` dies with `OutOfMemoryError: GC overhead limit exceeded`,
 give the Kotlin daemon more heap — append `-Pkotlin.daemon.jvmargs=-Xmx4g` (transforming some large
@@ -66,9 +66,10 @@ through a single JUnit runner, `AllCucumberFeaturesTest` (glue/step definitions 
   absent on a clean checkout — the *unversioned* `Given a snakemake project` scenarios (~135) then
   fail because `resolveQualifiedName("snakemake")` returns `[]`, while the checked-in per-version
   mocks (`MockPackages3_smk_<ver>`) still resolve. Provision it (see `DEVELOPER.md` → Configure Tests,
-  step 2): symlink snakemake **9.9.0**'s **`src/snakemake`** (modern `src/` layout) to
-  `testData/MockPackages3/snakemake`. **Two traps that make a correct fixture look like it does
-  nothing:** the version must match `snakemake_api.yaml`'s `defaultVersion` (9.9.0), and the test IDE
+  step 2): symlink` snakemake` to **`src/snakemake`** (https://github.com/snakemake/snakemake, checkout
+  desired version using repo tags) to `testData/MockPackages3/snakemake`. 
+  **Two traps that make a correct fixture look like it does nothing:** the version must match
+  `snakemake_api.yaml`'s `defaultVersion` (e.g. 9.9.0), and the test IDE
   sandbox persists a VFS/index under `.sandbox_pycharm/<ide>/system-test/` that **`cleanTest` doesn't
   clear** — if you add the fixture after a prior run, `rm -rf .sandbox_pycharm/*/system-test` once. If
   you see a wall of `snakemake`-resolution failures on a fresh checkout, suspect this fixture, **not**
@@ -93,6 +94,16 @@ Two languages, both layered onto the Python plugin:
 2. **SmkSL** — the Snakemake String Language embedded in strings like
    `"results/sample_{genome}.bam"`. Lives under `stringLanguage/`, lexer generated from
    `stringLanguage/lang/parser/smk_sl.flex` (JFlex), injected into Python string literals.
+
+SnakemCharm plugin features are based on the sources of the snakemake project 
+(https://github.com/snakemake/snakemake) so the plugin tries to do maximum static analysis of the underlying 
+snakemake python code. Due to the highly dynamic implementation of a snakemake framework the SnakeCharm 
+provides API descriptions of the implicit python api available in different blocks of Snakemake DSL. 
+Additionally, API changes among different snakemake versions, so snakemake version is considered 
+as `language level`. File `snakemake_api.yaml` (loaded by SnakemakeApiYamlAnnotationsService into project level
+`com.jetbrains.snakecharm.codeInsight.SnakemakeApiService` service class) describes API changes among 
+different snakemake versions. Key `defaultVersion` (e.g. 9.9.0) sets the default language level for the new 
+ projects, and it is the latest language level officially supported by the plugin.
 
 Feature areas (each maps to a source package and a `features/` test dir):
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,6 +35,10 @@ PyCharm Professional.
 Many test tasks need the wrappers repo path: append
 `-PsnakemakeWrappersRepoPath=testData/wrappers_storage`.
 
+**CLI build memory:** if `:compileKotlin` dies with `OutOfMemoryError: GC overhead limit exceeded`,
+give the Kotlin daemon more heap — append `-Pkotlin.daemon.jvmargs=-Xmx4g` (transforming some large
+generated methods can exhaust the default heap).
+
 ### Running tests
 
 Tests are **Cucumber/Gherkin** feature files under `src/test/resources/features/**`, executed
@@ -86,7 +90,10 @@ Feature areas (each maps to a source package and a `features/` test dir):
 - `lang/highlighter/`, `lang/validation/` — syntax highlighting + annotators (registered against
   Python; some run through `SmkStandardAnnotatorManager` / `SmkDumbAwareAnnotatorManager`).
 - `codeInsight/` — completion contributors and resolve for Snakemake magic (`config`, `rules`,
-  `rules.<name>.<section>`, wildcards, api methods like `expand`/`temp`, wrapper names).
+  `rules.<name>.<section>`, wildcards, api methods like `expand`/`temp`, wrapper names). The implicit
+  "runtime magic" symbols (`expand`, `temp`, `config`, `rules`, …) are built by
+  `SmkImplicitPySymbolsProvider`, which resolves them by qualified name against the project SDK's
+  snakemake package.
 - `inspections/` — ~56 local inspections for common Snakemake mistakes.
 - `framework/` — Snakemake framework detection: locating the `snakemake` package via the project
   SDK / package manager, which gates most features and drives version-specific behaviour.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,6 +46,17 @@ through a single JUnit runner, `AllCucumberFeaturesTest` (glue/step definitions 
   `testData/MockPackages3_smk_<version>/snakemake` (and a bare `testData/MockPackages3/snakemake`);
   cucumber steps select one via `Given a snakemake:<version> project`. Only the API files that
   differ between versions are copied into each mock (see `DEVELOPER.md` → Testdata).
+- **Fresh-checkout gotcha (saves hours):** `testData/MockPackages3/snakemake` is **gitignored** and
+  absent on a clean checkout — you must clone the snakemake repo and symlink it there (see
+  `DEVELOPER.md` → Configure Tests, step 2). Without it, a large batch (~100+) of resolve/completion
+  scenarios for the *unversioned* `snakemake` project fail — `resolveQualifiedName("snakemake")`
+  returns `[]` — while the checked-in per-version mocks (`MockPackages3_smk_<ver>`) still resolve. If
+  you see a wall of `snakemake`-resolution failures on a fresh checkout, suspect this missing
+  fixture, **not** your change.
+- **Analyzing results:** the full suite is large (~3200 scenarios; a full `test` run takes a while —
+  prefer the single-feature `@here` recipe while iterating). To triage or diff failures, parse
+  `build/test-results/test/TEST-*.xml`: each `<testcase>` with a `<failure>`/`<error>` child is a
+  failing scenario (name = `<feature> > <scenario> [#example]`).
 
 ## Architecture
 
@@ -89,3 +100,10 @@ the entry class for any feature is to grep that file.
   [build-number-ranges](https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html)
   (`2025.2`=`252`, `2026.1`=`261`, …). `DEVELOPER.md` → "Update to new Platform API" is the
   checklist for a platform bump.
+- **Platform-bump gotcha:** since 2025.2+ the platform is modular — APIs, inspections, and extension
+  points that used to live in *core* have been split into separate modules / bundled plugins with
+  their own classloaders. If a class or EP that worked before goes missing after a bump (often only
+  visible in tests), declare it explicitly with `bundledModule("…")` / `bundledPlugin("…")` in
+  `build.gradle.kts` and consult the
+  [API changes list](https://plugins.jetbrains.com/docs/intellij/api-changes-list-2025.html). (E.g.
+  `SpellCheckingInspection` moved from core to the Grazie plugin, `tanvd.grazi`.)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,91 @@
+# AGENTS.md
+
+Guidance for AI coding agents (and human newcomers) working in this repository. Kept
+tool-agnostic on purpose — see also `DEVELOPER.md` for the deep parser/lexer walkthrough and
+`README.md` for the user-facing feature list.
+
+## What this is
+
+**SnakeCharm** is an IntelliJ Platform plugin (Kotlin) that adds IDE support for the
+[Snakemake](https://snakemake.readthedocs.io/) workflow language to PyCharm and other
+IntelliJ-based IDEs. It is built **on top of the bundled Python plugin's PSI/API** — most of its
+extension points are registered against `language="Python"` and it extends Python parsing rather
+than defining a language from scratch.
+
+## Build & test
+
+The Gradle build uses a **JDK 21 toolchain** (`javaVersion` in `gradle.properties`) and the Gradle
+version pinned there (`gradleVersion`). Ensure a JDK 21 is visible to Gradle before building from
+the CLI (e.g. `export JAVA_HOME=$(/usr/libexec/java_home -v 21)`, or a jenv/asdf/SDKMAN shim).
+
+```shell
+./gradlew buildPlugin      # -> build/distributions/snakecharm-*.zip
+./gradlew test             # JUnit + Cucumber suite
+./gradlew runIde           # sandbox IDE with the plugin installed
+./gradlew verifyPlugin     # IntelliJ Plugin Verifier
+```
+
+The target IDE (`platformType`/`platformVersion` in `gradle.properties`) is downloaded
+automatically on first build (hundreds of MB). `platformType = PC` is PyCharm Community, `PY` is
+PyCharm Professional.
+
+Many test tasks need the wrappers repo path: append
+`-PsnakemakeWrappersRepoPath=testData/wrappers_storage`.
+
+### Running tests
+
+Tests are **Cucumber/Gherkin** feature files under `src/test/resources/features/**`, executed
+through a single JUnit runner, `AllCucumberFeaturesTest` (glue/step definitions in
+`src/test/kotlin/features/glue/`). There is no per-feature test class.
+
+- **Run one feature:** add a `@here` tag above its `Feature:` line and set
+  `tags = "not @ignore and @here"` in `AllCucumberFeaturesTest.kt`; revert both afterwards.
+- **`testData` is NOT a declared input of the `test` task.** After editing any feature or
+  test-data file, run `./gradlew cleanTest test` — plain `test` may serve stale cached results.
+- Test data lives in `testData/`. Snakemake API is mocked per-version under
+  `testData/MockPackages3_smk_<version>/snakemake` (and a bare `testData/MockPackages3/snakemake`);
+  cucumber steps select one via `Given a snakemake:<version> project`. Only the API files that
+  differ between versions are copied into each mock (see `DEVELOPER.md` → Testdata).
+
+## Architecture
+
+Two languages, both layered onto the Python plugin:
+
+1. **Snakemake** (`SnakemakeLanguageDialect`) — the `Snakefile` / `*.smk` / `*.rule(s)` files. Its
+   parser (`lang/parser/`) drives the Python `PyParser` API rather than a raw `PsiParser`: the
+   lexer/parser flip Snakemake keywords (`rule`, `checkpoint`, …) from Python identifiers to
+   Snakemake token types **only outside pure-python blocks** (`run:`/`onstart`/`onsuccess`/
+   `onerror`), and delegate everything else to the Python parser. PSI lives in `lang/psi/`
+   (`SmkFile`, sections, rules), custom PSI types in `lang/psi/types/`, references in
+   `lang/psi/references/`, stubs in `lang/psi/stubs/`.
+
+2. **SmkSL** — the Snakemake String Language embedded in strings like
+   `"results/sample_{genome}.bam"`. Lives under `stringLanguage/`, lexer generated from
+   `stringLanguage/lang/parser/smk_sl.flex` (JFlex), injected into Python string literals.
+
+Feature areas (each maps to a source package and a `features/` test dir):
+
+- `lang/highlighter/`, `lang/validation/` — syntax highlighting + annotators (registered against
+  Python; some run through `SmkStandardAnnotatorManager` / `SmkDumbAwareAnnotatorManager`).
+- `codeInsight/` — completion contributors and resolve for Snakemake magic (`config`, `rules`,
+  `rules.<name>.<section>`, wildcards, api methods like `expand`/`temp`, wrapper names).
+- `inspections/` — ~56 local inspections for common Snakemake mistakes.
+- `framework/` — Snakemake framework detection: locating the `snakemake` package via the project
+  SDK / package manager, which gates most features and drives version-specific behaviour.
+- `lang/structureView/`, `lang/documentation/`, `lang/formatter/`, `spellchecker/`, `actions/` —
+  the corresponding IDE integrations.
+
+Extension points are wired in `src/main/resources/META-INF/plugin.xml` — the fastest way to find
+the entry class for any feature is to grep that file.
+
+## Build / platform conventions
+
+- `gradle.properties` is the single source of truth for the target platform: `platformType`,
+  `platformVersion`, `pluginSinceBuild`, `pluginUntilBuild`, `platformBundledPlugins`.
+- Plugin version scheme (`pluginVersion`) is `YEAR.MAJOR.MINOR`, where `YEAR.MAJOR` is the
+  **minimal compatible platform** and `MINOR` is the plugin build digit. A new `pluginVersion`
+  must also get a matching section in `CHANGELOG.md`, or `patchPluginXml` fails.
+- Build numbers map to IDE versions per
+  [build-number-ranges](https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html)
+  (`2025.2`=`252`, `2026.1`=`261`, …). `DEVELOPER.md` → "Update to new Platform API" is the
+  checklist for a platform bump.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md


### PR DESCRIPTION
Adds a top-level `AGENTS.md`: a tool-agnostic orientation file for AI coding agents (and human newcomers) working in this repo. It complements, and defers to, `DEVELOPER.md` and `README.md` rather than duplicating them — the aim is the handful of things that cost hours to discover and are not written down anywhere.

Everything in it was learned the hard way while working on #570, #572, #574 and #577, and every claim was re-checked against the tree, not against memory of the session that produced it.

### Contents

- **What the plugin is** — an IntelliJ Platform plugin layered on the bundled Python plugin's PSI/API (most EPs registered against `language="Python"`).

- **Build** — the JDK 21 toolchain, including two traps: the pinned Gradle crashes under a much newer JVM with `Type T not present`, and on macOS `/usr/libexec/java_home -v 21` treats 21 as a *minimum*, so it happily returns a newer JDK and exits 0. Also the Kotlin-daemon OOM workaround, and what `snakemakeWrappersRepoPath` does and does not gate now that #572 has made it optional (issue #571): it fronts `buildPlugin` and `runIde`, but **not** the test tasks, which route through `prepareTestSandbox` and the separate test-only bundle.

- **Running tests** — the recipes that turn a 25-minute suite into a 60-second one and stop a stale run from lying to you: the `@here` tag plus the `AllCucumberFeaturesTest` filter; `cleanTest` because `testData` is not a declared input of `test`; that scenarios share one cached project whenever they hand the light-fixture framework the same `LightProjectDescriptor`, so a step must set the project state it needs rather than assume a fresh default; how to triage a wall of failures out of `build/test-results/test/TEST-*.xml`; and the fresh-checkout `testData/MockPackages3/snakemake` fixture whose absence costs ~135 spurious failures (#574).

- **Architecture** — the two languages (Snakemake driving the Python `PyParser` API; SmkSL injected into strings), snakemake versions as language levels via `snakemake_api.yaml`, the feature-area → package → `features/` test-dir mapping, and the "grep `plugin.xml` to find a feature's entry class" tip.

- **Platform conventions** — `gradle.properties` as the source of truth, the `YEAR.MAJOR.MINOR` scheme and its `CHANGELOG.md` requirement, that 2025.2 is the last standalone PyCharm Community release, that a platform bump also moves the Kotlin compiler / Java toolchain / `intelliJPlatform` baselines (each failing before your source is even considered), that `TestLoggerFactory` turns one logged error into hundreds of failed scenarios, and the post-2025.2 modular-platform gotcha requiring explicit `bundledModule`/`bundledPlugin` declarations.

## Notes for reviewers

- **Is an `AGENTS.md` welcome here at all?** That is the real question this PR asks, which is why it is deliberately separate from any feature work — it can be declined without affecting anything else.
- Naming is a choice: `AGENTS.md` is the emerging cross-tool convention, so the content lives there once. Claude Code is the exception — it reads `CLAUDE.md` — so this PR also adds a one-line `CLAUDE.md` containing `@AGENTS.md`, an import rather than a copy, so there is nothing to keep in sync. Happy to rename either file, or fold the content into `DEVELOPER.md`, if you would rather have one file.
- If you disagree with a claim in it, that is a bug worth filing — the file is only useful if it is exactly right.

Related: #574 (the fixture fix behind the "fresh-checkout gotcha" section), #570 / #577 (the platform ports that produced the bump notes), #572 (wrappers path, merged), #585 (build-side follow-ups found while checking this file's wrappers claims).

<details>
<summary><b>Review history</b> — kept for anyone tracing why a particular line reads the way it does; the durable conclusions are all in the file above.</summary>

- The wrappers paragraph originally claimed `buildWrappersBundle` "sits in front of `buildPlugin`, `runIde` **and** the test tasks". It does not: only `prepareSandbox` depends on it, and `test --dry-run` never lists it. Corrected, and the same wrong claim in a `build.gradle.kts` comment is fixed in #585.
- The shared-test-project paragraph first only alluded to the trap; it now says what actually causes it (same `LightProjectDescriptor` → same cached project) and gives `Given a snakemake with disabled framework project` as the cautionary example.
- Reviewing this file's build claims turned up three real build-script problems — a silent wrapper-less publish on CI, an empty property taking the quiet path, and a stale bundle that could be packed — none of which belong in a docs PR. They are #585.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
