### PR TITLE
Fail the test, not the JVM, when the test wrappers bundle is missing

### DIFF
--- a/src/main/kotlin/com/jetbrains/snakecharm/codeInsight/completion/wrapper/SmkWrapperStorage.kt
+++ b/src/main/kotlin/com/jetbrains/snakecharm/codeInsight/completion/wrapper/SmkWrapperStorage.kt
@@ -22,7 +22,6 @@ import java.nio.file.Files
 import java.nio.file.Path
 import java.util.*
 import kotlin.io.path.exists
-import kotlin.system.exitProcess
 
 class SmkWrapperStorage(val project: Project) : Disposable {
     var version = ""
@@ -185,11 +184,12 @@ class SmkWrapperStorage(val project: Project) : Disposable {
                 .resolve("build/bundledWrappers/smk-wrapper-storage.test.cbor")
 
             if (!wrappersInfoBundlerForTests.exists()) {
-                System.err.println(
-                    "Generate test data 'build/bundledWrappers/smk-wrapper-storage.test.cbor'" +
-                            " using `buildTestWrappersBundle` gradle task"
+                // Fail this test, not the whole JVM: exitProcess() here killed the Gradle test worker,
+                // so the run ended with a worker-crash message instead of naming the missing test data.
+                error(
+                    "Missing test wrappers bundle: '$wrappersInfoBundlerForTests'." +
+                            " Generate it using the `buildTestWrappersBundle` gradle task."
                 )
-                exitProcess(1)
             }
 
             val (repoVersion, wrappers) = deserializeWrappers(wrappersInfoBundlerForTests)


### PR DESCRIPTION
## What & why

When the test wrappers bundle is missing, `SmkWrapperStorage.loadBundledWrappersTestsMode` prints a hint to stderr and then calls `exitProcess(1)`. That kills the Gradle test worker in the middle of the run, so what actually ends the session is the JVM vanishing — the helpful part («generate it with `buildTestWrappersBundle`») is on the console, but the thing that stops the build is a worker-crash message, and nothing about it reaches the test report.

This is easy to hit: `build/` is not checked in, so any developer whose `build/bundledWrappers/smk-wrapper-storage.test.cbor` is absent — a fresh checkout where the task hasn't run, a `clean`, or a run configuration that skips `buildTestWrappersBundle` — gets a dead worker rather than a named cause.

## The change

Throw instead of exiting. The suite keeps running, the affected scenarios fail normally, and the message names both the missing file and the task that generates it:

```
Missing test wrappers bundle: '<path>/build/bundledWrappers/smk-wrapper-storage.test.cbor'.
Generate it using the `buildTestWrappersBundle` gradle task.
```

The now-unused `kotlin.system.exitProcess` import is removed. Nothing else changes — this is test-mode-only code (`loadBundledWrappersTestsMode` is reached only under `ApplicationManager.getApplication().isUnitTestMode`), so no production path is affected.

## Verification

Not just compiled — the failure path was exercised directly. I generated the bundle, moved it aside, tagged a single wrapper feature `@here`, and ran with `-x buildTestWrappersBundle` so it could not be regenerated:

```
198 tests completed, 19 failed
AllCucumberFeaturesTest > Completion for wrapper name... FAILED
    Caused by: java.lang.IllegalStateException at SmkWrapperStorage.kt:190
```

The run terminated normally and the message appears in `build/test-results/test/*.xml`. Previously the same conditions took the worker down instead.

## Scope

Independent of #572 and #574 — it touches neither the wrappers-bundle build logic nor the fixture docs, and is branched from `master` so it can be reviewed and merged on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
