### PR TITLE
Fail the build instead of silently shipping a plugin without bundled wrappers

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -243,6 +243,10 @@ kotlin {
     }
 }
 
+// A local snakemake-wrappers checkout (see DEVELOPER.md); CI provides one. Unset for most
+// contributors, in which case the plugin is built without bundled wrappers -- see buildWrappersBundle.
+val wrappersRepoPath = gradlePropertyOptional("snakemakeWrappersRepoPath")
+
 tasks {
 
     runIde {
@@ -286,7 +290,6 @@ tasks {
         // On CI the property is mandatory. A dropped TeamCity parameter would otherwise publish a
         // wrapper-less plugin from a green build, with nothing but a warning in the log. Checked when
         // the task graph is ready, not in onlyIf: Gradle hides the message of an onlyIf failure.
-        val wrappersRepoPath = gradlePropertyOptional("snakemakeWrappersRepoPath")
         if (providers.environmentVariable("TEAMCITY_VERSION").isPresent && wrappersRepoPath == null) {
             gradle.taskGraph.whenReady {
                 if (hasTask(":buildWrappersBundle")) {
@@ -298,7 +301,6 @@ tasks {
                 }
             }
         }
-        val wrappersBundleFile = layout.buildDirectory.file("bundledWrappers/smk-wrapper-storage-bundled.cbor")
         onlyIf {
             if (wrappersRepoPath == null) {
                 logger.warn(
@@ -307,9 +309,6 @@ tasks {
                         "name completion will be unavailable). " +
                         "Pass -PsnakemakeWrappersRepoPath=<snakemake-wrappers checkout> to include them. See #571."
                 )
-                // Drop a bundle left by an earlier run that did have the property, so prepareSandbox
-                // cannot pack a stale one whose embedded repo version disagrees with gradle.properties.
-                wrappersBundleFile.get().asFile.delete()
             }
             wrappersRepoPath != null
         }
@@ -351,8 +350,12 @@ tasks {
         // Pack wrappers bundle into plugin:
         dependsOn("buildWrappersBundle")
 
-        from(layout.buildDirectory.file("bundledWrappers/smk-wrapper-storage-bundled.cbor")) {
-            into(pluginName.map { "$it/extra" })
+        // Only when one is actually built. Otherwise a bundle left in build/ by an earlier run that did
+        // have the property gets packed, and its embedded repo version disagrees with gradle.properties.
+        if (wrappersRepoPath != null) {
+            from(layout.buildDirectory.file("bundledWrappers/smk-wrapper-storage-bundled.cbor")) {
+                into(pluginName.map { "$it/extra" })
+            }
         }
         from(layout.projectDirectory.file("snakemake_api.yaml")) {
             into(pluginName.map { "$it/extra" })

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -325,7 +325,8 @@ tasks {
     register<JavaExec>("buildTestWrappersBundle") {
         // XXX: we could re-use wrappers bundle task for production here and just pass:
         //  `-PsnakemakeWrappersRepoPath=testData/wrappers_storage' gradle arg
-        // P.S: Wrappers bundle task for production always executed before tests in order to get JAR file
+        // P.S: tests never run the production bundle task -- they go through prepareTestSandbox, which
+        // depends on this one instead.
 
         // Builds storage based on test data
         dependsOn("compileKotlin", "compileJava")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -327,8 +327,8 @@ tasks {
     register<JavaExec>("buildTestWrappersBundle") {
         // XXX: we could re-use wrappers bundle task for production here and just pass:
         //  `-PsnakemakeWrappersRepoPath=testData/wrappers_storage' gradle arg
-        // P.S: tests never run the production bundle task -- they go through prepareTestSandbox, which
-        // depends on this one instead.
+        // P.S: tests never run the production bundle task -- the `test` task depends on this one directly,
+        // and tests read the .cbor from build/bundledWrappers.
 
         // Builds storage based on test data
         dependsOn("compileKotlin", "compileJava")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -289,8 +289,10 @@ tasks {
         //
         // On CI the property is mandatory. A dropped TeamCity parameter would otherwise publish a
         // wrapper-less plugin from a green build, with nothing but a warning in the log. Checked when
-        // the task graph is ready, not in onlyIf: Gradle hides the message of an onlyIf failure.
-        if (providers.environmentVariable("TEAMCITY_VERSION").isPresent && wrappersRepoPath == null) {
+        // the task graph is ready, not in onlyIf: Gradle hides the message of an onlyIf failure. Blank
+        // counts as unset here: an unresolved TeamCity parameter arrives as an empty string, and an empty
+        // path resolves to the daemon working directory, which the crawler may well accept.
+        if (providers.environmentVariable("TEAMCITY_VERSION").isPresent && wrappersRepoPath.isNullOrBlank()) {
             gradle.taskGraph.whenReady {
                 if (hasTask(":buildWrappersBundle")) {
                     throw GradleException(

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -279,10 +279,25 @@ tasks {
         // CI provides one. When the property is unset, skip with a warning instead of failing
         // buildPlugin/verifyPlugin for contributors who don't have it. See issue #571.
         //
-        // Skip only when it is *unset*. If it is set but wrong (a typo, or a renamed CI checkout) the
-        // task still runs and SmkWrapperCrawler fails loudly, as before -- silently publishing a plugin
-        // with no wrapper metadata is a much worse outcome than a broken build.
-        val wrappersRepoPath = gradlePropertyOptional("snakemakeWrappersRepoPath")?.takeIf { it.isNotBlank() }
+        // Skip only when it is *unset*. If it is set but wrong -- a typo, an empty value, or a renamed
+        // CI checkout -- the task still runs and SmkWrapperCrawler fails loudly, as before: silently
+        // publishing a plugin with no wrapper metadata is a much worse outcome than a broken build.
+        //
+        // On CI the property is mandatory. A dropped TeamCity parameter would otherwise publish a
+        // wrapper-less plugin from a green build, with nothing but a warning in the log. Checked when
+        // the task graph is ready, not in onlyIf: Gradle hides the message of an onlyIf failure.
+        val wrappersRepoPath = gradlePropertyOptional("snakemakeWrappersRepoPath")
+        if (providers.environmentVariable("TEAMCITY_VERSION").isPresent && wrappersRepoPath == null) {
+            gradle.taskGraph.whenReady {
+                if (hasTask(":buildWrappersBundle")) {
+                    throw GradleException(
+                        "snakemakeWrappersRepoPath is not set on CI. Refusing to build a plugin without " +
+                            "bundled wrappers -- check the snakemake-wrappers VCS root and the parameter " +
+                            "that passes its path to Gradle. See #571."
+                    )
+                }
+            }
+        }
         val wrappersBundleFile = layout.buildDirectory.file("bundledWrappers/smk-wrapper-storage-bundled.cbor")
         onlyIf {
             if (wrappersRepoPath == null) {


### PR DESCRIPTION
Follow-up to #571 / #572. The wrappers-bundle skip added in #572 keeps `buildPlugin` working for contributors without a local `snakemake-wrappers` checkout, but it is too quiet in three places, and each one ends the same way: a green build that ships, packs, or claims the wrong thing.

## What's here

- **CI can no longer publish a wrapper-less plugin from a green build.** When the property is unset the bundle is skipped with a warning, which is right locally and wrong on TeamCity: a renamed VCS root or a dropped parameter yields a plugin with no `extra/smk-wrapper-storage-bundled.cbor`, and wrapper name completion simply offers nothing. On TeamCity it is now a hard failure whenever `:buildWrappersBundle` is in the task graph, with a message naming the VCS root and the parameter. The check sits in `taskGraph.whenReady` rather than `onlyIf` because Gradle reports an `onlyIf` failure as "Could not evaluate spec" and swallows the message.

- **A blank value no longer slips past that check.** `-PsnakemakeWrappersRepoPath=` is exactly the shape an unresolved TeamCity parameter has, and it is non-null, so a `== null` guard would let it through to the crawler — where an empty path resolves to the Gradle daemon's working directory, which exists and is a directory. The build would then die on `Wrappers src folder doesn't contain "bio" folder: []` with nothing pointing at the parameter, or, on an agent whose working directory happens to contain a `bio` folder, succeed with a zero-wrapper bundle. On CI, blank counts as unset. Locally it still runs the crawler and fails loudly, as DEVELOPER.md promises for a set-but-wrong path.

- **A stale bundle can no longer be packed.** The skip deleted the old bundle from `build/` inside its own `onlyIf` predicate — a side effect in a spec that Gradle may evaluate more than once, never evaluates under `--dry-run`, and whose return value was ignored, so a failed delete silently packed the stale file. `prepareSandbox` now copies the bundle only when the property is set; being a `Sync`, it clears a previously packed copy on its own, so nothing has to be deleted from `build/` at all.

Also corrects a stale comment in `buildTestWrappersBundle` that claimed the production bundle task always runs before tests. It does not: the `test` task depends on `buildTestWrappersBundle` directly, and the tests read the `.cbor` from `build/bundledWrappers` rather than from any sandbox.

## What it deliberately does not do

- **No path validation beyond what `SmkWrapperCrawler` already does.** A set-but-wrong path is still diagnosed by the crawler, not by the build script.
- **No change to the unset-and-local path.** That is #572's behaviour and it stays: one warning, task skipped, plugin builds without bundled wrappers.
- **CI is detected by `TEAMCITY_VERSION` only.** That is where this project's releases are built; a GitHub Actions guard can be added if that ever changes.

## Verification

Ran locally on JDK 21:

| Case | Result |
| --- | --- |
| unset, local | skips with the warning, build succeeds |
| unset, `TEAMCITY_VERSION` set, task in graph | fails with the CI message above |
| unset, `TEAMCITY_VERSION` set, task not in graph (`help`) | succeeds |
| blank, `TEAMCITY_VERSION` set | same hard failure, naming the VCS root and the parameter |
| blank, local | crawler runs and fails: `Wrappers src folder doesn't contain "bio" folder: []` |
| stale `.cbor` in `build/`, property unset | sandbox `extra/` holds only `snakemake_api.yaml` |
| `-PsnakemakeWrappersRepoPath=testData/wrappers_storage` | 23 wrappers crawled, bundle packed |

## Before merging

- [ ] Confirm on TeamCity that the wrappers parameter does reach Gradle, so the new guard fires on a real misconfiguration and not on a correct one. This is why the PR is still a draft.

<details>
<summary><b>Review history</b> — one round, one commit per finding. Kept for anyone tracing why a particular line looks the way it does; the durable conclusions are in the code comments above.</summary>

- The first pass at the CI guard tested `wrappersRepoPath == null` while the same commit dropped the `?.takeIf { it.isNotBlank() }` that used to normalise a blank value to null — so the actionable CI message would have been skipped for exactly the failure mode it was written for. Fixed in `17b1abe`; the guard is `isNullOrBlank()`, while `onlyIf` deliberately stays `== null` so a blank value keeps failing loudly for local builds.
- The replacement comment in `buildTestWrappersBundle` reached the right conclusion by the wrong route: it said tests go through `prepareTestSandbox`, which depends on the test bundle task. `prepareTestSandbox` has no such dependency — the `test` task declares it. Corrected in `0fb06b3`.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
